### PR TITLE
Add response.end capture support

### DIFF
--- a/src/instrumentation/BodyCapture.ts
+++ b/src/instrumentation/BodyCapture.ts
@@ -6,19 +6,18 @@ export class BodyCapture {
     private maxReportingSize: number;
     private full: boolean
     private maxProcessingSize: number;
-    private contentLength: number
-
+    private contentLength: number;
     // whichever is larger(processing or reporting) use that to limit how much data BodyCapture will record
     private internalMaxRecordingSize: number;
 
     constructor(maxSize : number, maxProcessingSize : number) {
         this.data = []
-        this.contentLength = 0
         this.currentSize = 0
         this.maxReportingSize = maxSize  // data that is sent out for reporting
         this.maxProcessingSize = maxProcessingSize // data that is sent to filter api internally
         this.internalMaxRecordingSize = Math.max(maxSize, maxProcessingSize);
         this.full = false
+        this.contentLength = 0;
     }
 
     appendData(chunk : any) {
@@ -44,16 +43,16 @@ export class BodyCapture {
             this.data.push(gapFill)
             this.full = true
         }
-        this.contentLength += chunk.length
+        this.contentLength += chunk.length;
         this.currentSize += chunkSize
-    }
-
-    getContentLength() : number {
-        return this.contentLength;
     }
 
     processableString() : string {
         return Buffer.concat(this.data).toString('utf8', 0, this.maxProcessingSize)
+    }
+
+    getContentLength() {
+        return this.contentLength;
     }
 
     dataString() : string{

--- a/src/instrumentation/BodyCapture.ts
+++ b/src/instrumentation/BodyCapture.ts
@@ -6,12 +6,14 @@ export class BodyCapture {
     private maxReportingSize: number;
     private full: boolean
     private maxProcessingSize: number;
+    private contentLength: number
 
     // whichever is larger(processing or reporting) use that to limit how much data BodyCapture will record
     private internalMaxRecordingSize: number;
 
     constructor(maxSize : number, maxProcessingSize : number) {
         this.data = []
+        this.contentLength = 0
         this.currentSize = 0
         this.maxReportingSize = maxSize  // data that is sent out for reporting
         this.maxProcessingSize = maxProcessingSize // data that is sent to filter api internally
@@ -42,7 +44,12 @@ export class BodyCapture {
             this.data.push(gapFill)
             this.full = true
         }
+        this.contentLength += chunk.length
         this.currentSize += chunkSize
+    }
+
+    getContentLength() : number {
+        return this.contentLength;
     }
 
     processableString() : string {

--- a/src/instrumentation/HttpHypertraceInstrumentation.ts
+++ b/src/instrumentation/HttpHypertraceInstrumentation.ts
@@ -449,12 +449,10 @@ export class HttpHypertraceInstrumentation extends InstrumentationBase<Http> {
                         ..._args: ResponseEndArgs
                     ) {
                         response.end = originalEnd;
+                        ResponseEnded(span, this, _args)
                         // Cannot pass args of type ResponseEndArgs,
                         const returned = safeExecuteInTheMiddle(
-                            () => {
-                                ResponseEnded(span, this, _args)
-                                response.end.apply(this, arguments as never)
-                            },
+                            () => response.end.apply(this, arguments as never),
                             error => {
                                 if (error) {
                                     utils.setSpanWithError(span, error);

--- a/src/instrumentation/HttpHypertraceInstrumentation.ts
+++ b/src/instrumentation/HttpHypertraceInstrumentation.ts
@@ -52,6 +52,7 @@ import { RPCMetadata, RPCType, setRPCMetadata } from '@opentelemetry/core';
 import {IncomingMessage} from "http";
 import {filter} from "rxjs/operators";
 import {MESSAGE, STATUS_CODE} from "../filter/Filter";
+import {ResponseEnded} from "./wrapper/ExpressWrapper";
 
 /**
  * Http instrumentation instrumentation for Opentelemetry
@@ -450,7 +451,10 @@ export class HttpHypertraceInstrumentation extends InstrumentationBase<Http> {
                         response.end = originalEnd;
                         // Cannot pass args of type ResponseEndArgs,
                         const returned = safeExecuteInTheMiddle(
-                            () => response.end.apply(this, arguments as never),
+                            () => {
+                                ResponseEnded(span, this, _args)
+                                response.end.apply(this, arguments as never)
+                            },
                             error => {
                                 if (error) {
                                     utils.setSpanWithError(span, error);

--- a/src/instrumentation/wrapper/ExpressWrapper.ts
+++ b/src/instrumentation/wrapper/ExpressWrapper.ts
@@ -2,9 +2,9 @@ import {context, trace} from "@opentelemetry/api";
 import {Config} from "../../config/config";
 import {HttpInstrumentationWrapper} from "../HttpInstrumentationWrapper";
 import {BodyCapture} from "../BodyCapture";
-import {MESSAGE} from "../../filter/Filter";
 import {logger} from "../../Logging";
-
+import {patch} from "semver";
+let patched = false
 const shimmer = require('shimmer');
 export function available(mod : string){
     try {
@@ -19,17 +19,21 @@ export function ResponseEnded(span, response, responseEndArgs) {
     try { // this call happens within a SafeExecuteInTheMiddle;
           // a raised exception will prevent the original resp.apply.end from being applied
           // which would cause some of the response not to write to client
-        if(span && span.inHtScope != true) {
-
+        if(span) {
             // @ts-ignore
-            let headerContentType =  response.get('Content-Type')
-            if(HttpInstrumentationWrapper.isRecordableContentType(headerContentType)) {
+            if (span.inHtCaptureScope != true) {
                 // @ts-ignore
-                let bodyCapture : BodyCapture = span.hypertraceBodyCapture ||  new BodyCapture(Config.getInstance().config.data_capture.body_max_size_bytes,
-                    Config.getInstance().config.data_capture.body_max_processing_size_bytes)
-                if(response.get('Content-Length') == bodyCapture.getContentLength()){ return }
-                bodyCapture.appendData(responseEndArgs[0])
-                span.setAttribute('http.response.body', bodyCapture.dataString())
+                let headerContentType = response.get('Content-Type')
+                if (HttpInstrumentationWrapper.isRecordableContentType(headerContentType)) {
+                    // @ts-ignore
+                    let bodyCapture: BodyCapture = span.hypertraceBodyCapture || new BodyCapture(Config.getInstance().config.data_capture.body_max_size_bytes,
+                        Config.getInstance().config.data_capture.body_max_processing_size_bytes)
+                    // the response may have been chunked during send & nested end call;
+                    // if so & content lengths are the same, we already captured entire body
+                    if(response.get('Content-Length') == bodyCapture.getContentLength().toString()) { return }
+                    bodyCapture.appendData(responseEndArgs[0])
+                    span.setAttribute('http.response.body', bodyCapture.dataString())
+                }
             }
         }
     } catch (e) {
@@ -43,40 +47,47 @@ function ResponseCaptureWithConfig(config : any) : Function {
         const responseBodyEnabled = config.config.data_capture.http_body.response
         const maxCaptureSize = config.config.data_capture.body_max_size_bytes
         return function(){
+            let capturedChunk = false
             let span = trace.getSpan(context.active())
             if(responseBodyEnabled) {
                 if(span) {
                     // @ts-ignore
-                    let headerContentType =  this.get('Content-Type')
-                    if(HttpInstrumentationWrapper.isRecordableContentType(headerContentType)) {
-                        let bodyCapture : BodyCapture;
+                    if (span.inHtCaptureScope != true) {
                         // @ts-ignore
-                        if(span.hypertraceBodyCapture) {
+                        let headerContentType =  this.get('Content-Type')
+                        if(HttpInstrumentationWrapper.isRecordableContentType(headerContentType)) {
                             // @ts-ignore
-                            bodyCapture = span.hypertraceBodyCapture;
-                        } else {
-                            bodyCapture = new BodyCapture(Config.getInstance().config.data_capture.body_max_size_bytes,
-                                Config.getInstance().config.data_capture.body_max_processing_size_bytes)
+                            if(!span.hypertraceBodyCapture) {
+                                // @ts-ignore
+                                span.hypertraceBodyCapture = new BodyCapture(Config.getInstance().config.data_capture.body_max_size_bytes,
+                                    Config.getInstance().config.data_capture.body_max_processing_size_bytes)
+                            }
                             // @ts-ignore
-                            span.hypertraceBodyCapture = bodyCapture;
+                            span.hypertraceBodyCapture.appendData(arguments[0])
+                            capturedChunk = true
+                            // @ts-ignore
+                            span.setAttribute('http.response.body', span.hypertraceBodyCapture.dataString())
                         }
-
-                        bodyCapture.appendData(arguments[0])
-                        span.setAttribute('http.response.body', bodyCapture.dataString())
                     }
                 }
             }
+            // sometimes we can't capture a chunk at a certain scope because content-type isn't set yet,
+            // in that case we dont want to enter scope until we have captured
             // @ts-ignore
-            return original.apply(this, arguments)
+            span.inHtCaptureScope = capturedChunk;
+            let ret =  original.apply(this, arguments)
+            // @ts-ignore
+            span.inHtCaptureScope = false;
+            return ret
         }
     }
 }
 
 export function patchExpress(){
-    if(!available('express')){
+    if(!available('express') || patched){
         return
     }
+    patched = true
     const express = require('express')
     shimmer.wrap(express.response, 'send', ResponseCaptureWithConfig(Config.getInstance()))
-    shimmer.wrap(express.response, 'json', ResponseCaptureWithConfig(Config.getInstance()))
 }


### PR DESCRIPTION
## Description
`Express.response.end` isn't capture; we can't wrap this method the same way we do other `resp.send` / `resp.json` because of the way http instrumentation replaces the definition during a request.
