### PR TITLE
allow version attribute override

### DIFF
--- a/src/HypertraceAgent.ts
+++ b/src/HypertraceAgent.ts
@@ -43,12 +43,12 @@ export class HypertraceAgent {
     public config: Config
     public exporter: SpanExporter | undefined
 
-    public constructor() {
+    public constructor(overrideVersion?: string ) {
         logger.info("Initializing Hypertrace Agent")
         logger.info(`Hypertrace Version: ${version}`)
         logger.info(`Node version: ${process.version}`)
         this.config = Config.getInstance()
-        this._provider = this.setupTracingProvider()
+        this._provider = this.setupTracingProvider(overrideVersion)
         logger.info("Successfully initialized Hypertrace Agent")
     }
 
@@ -103,11 +103,12 @@ export class HypertraceAgent {
     }
 
 
-    private setupTracingProvider(): NodeTracerProvider {
+    private setupTracingProvider(overrideVersion?: string): NodeTracerProvider {
+        let reportedVersion = overrideVersion ? overrideVersion : version
         let resourceAttributes = {
             'service.name': this.config.config.service_name,
             'service.instance.id': process.pid,
-            'telemetry.sdk.version': version,
+            'telemetry.sdk.version': reportedVersion,
             'telemetry.sdk.name': 'hypertrace',
             'telemetry.sdk.language': 'nodejs'
         }

--- a/test/instrumentation/AgentForTest.ts
+++ b/test/instrumentation/AgentForTest.ts
@@ -11,12 +11,12 @@ import {
 export class AgentForTest extends HypertraceAgent {
     private static instance: AgentForTest;
 
-    private constructor() {
-        super()
+    private constructor(overrideVersion?: string) {
+        super(overrideVersion)
     }
 
-    public static renew() {
-        AgentForTest.instance = new AgentForTest()
+    public static renew(overrideVersion?: string) {
+        AgentForTest.instance = new AgentForTest(overrideVersion)
     }
 
     public static getInstance(): AgentForTest {

--- a/test/instrumentation/HypertraceAgentTest.ts
+++ b/test/instrumentation/HypertraceAgentTest.ts
@@ -64,4 +64,10 @@ describe('Agent tests', () => {
         expect(provider.resource.attributes['another_attr']).to.equal('foo')
         Config.getInstance().config.resource_attributes = original
     })
+
+    it('will override the version if provided', () => {
+        AgentForTest.renew('1.2.3')
+        let provider = AgentForTest.getInstance()._provider
+        expect(provider.resource.attributes['telemetry.sdk.version']).to.equal('1.2.3')
+    })
 });


### PR DESCRIPTION
## Description
If a library extends hypertrace we should optionally report that library version instead.