### PR TITLE
fix: Handle errors when middleware isnt present

### DIFF
--- a/src/instrumentation/Framework.ts
+++ b/src/instrumentation/Framework.ts
@@ -1,0 +1,38 @@
+export class Framework {
+    private static instance: Framework | undefined;
+    public config: any
+
+    private frameworks : Map<string, boolean>
+    static supportedFrameworks = ['express', 'koa', 'nestjs', 'sails']
+
+    private constructor() {
+        this.frameworks = new Map<string, boolean>()
+        for(let framework of Framework.supportedFrameworks) {
+            this.frameworks[framework] = this.available(framework)
+        }
+    }
+
+    public static getInstance(): Framework {
+        if (!Framework.instance) {
+            Framework.instance = new Framework();
+        }
+
+        return Framework.instance;
+    }
+
+    // if a framework is not just express(but a framework on top of express)
+    // we can pass filter error up middleware chain cleanly from event based body read
+    // if it is purely express, we need to end response immediately
+    public isPureExpress = () => {
+        return !(this.frameworks['sails'] || this.frameworks['nestjs'] || this.frameworks['koa']);
+    }
+
+    available = (mod : string) => {
+        try {
+            require.resolve(mod)
+            return true
+        } catch {
+            return false
+        }
+    }
+}

--- a/src/instrumentation/Framework.ts
+++ b/src/instrumentation/Framework.ts
@@ -2,12 +2,12 @@ export class Framework {
     private static instance: Framework | undefined;
     public config: any
 
-    private frameworks : Map<string, boolean>
+    private frameworks: Map<string, boolean>
     static supportedFrameworks = ['express', 'koa', 'nestjs', 'sails']
 
     private constructor() {
         this.frameworks = new Map<string, boolean>()
-        for(let framework of Framework.supportedFrameworks) {
+        for (let framework of Framework.supportedFrameworks) {
             this.frameworks[framework] = this.available(framework)
         }
     }
@@ -27,7 +27,7 @@ export class Framework {
         return !(this.frameworks['sails'] || this.frameworks['nestjs'] || this.frameworks['koa']);
     }
 
-    available = (mod : string) => {
+    available = (mod: string) => {
         try {
             require.resolve(mod)
             return true

--- a/src/instrumentation/HttpInstrumentationWrapper.ts
+++ b/src/instrumentation/HttpInstrumentationWrapper.ts
@@ -6,7 +6,7 @@ import {
     RequestOptions,
     ServerResponse
 } from "http";
-import {context, Span, SpanAttributes, trace} from "@opentelemetry/api";
+import {context, Span, SpanAttributes} from "@opentelemetry/api";
 import {hypertrace} from "../config/generated";
 import {AttrWrapper} from "./AttrWrapper";
 import {BodyCapture} from "./BodyCapture";
@@ -110,7 +110,7 @@ export class HttpInstrumentationWrapper {
                                 // set the desired response
                                 if (Framework.getInstance().isPureExpress()) {
                                     // @ts-ignore
-                                    request.res.status(403)
+                                    request.res.status(STATUS_CODE)
                                     // @ts-ignore
                                     request.res.end()
                                     // @ts-ignore
@@ -118,9 +118,9 @@ export class HttpInstrumentationWrapper {
                                     throw filterError()
                                 } else {
                                     // @ts-ignore
-                                    request.res.statusCode = 403
+                                    request.res.statusCode = STATUS_CODE
                                     // @ts-ignore
-                                    request.res.statusMessage = 'FORBIDDEN'
+                                    request.res.statusMessage = MESSAGE
                                     // @ts-ignore
                                     request.next(filterError())
                                 }

--- a/src/instrumentation/wrapper/ExpressWrapper.ts
+++ b/src/instrumentation/wrapper/ExpressWrapper.ts
@@ -3,10 +3,11 @@ import {Config} from "../../config/config";
 import {HttpInstrumentationWrapper} from "../HttpInstrumentationWrapper";
 import {BodyCapture} from "../BodyCapture";
 import {logger} from "../../Logging";
-import {patch} from "semver";
+
 let patched = false
 const shimmer = require('shimmer');
-export function available(mod : string){
+
+export function available(mod: string) {
     try {
         require.resolve(mod)
         return true
@@ -17,9 +18,9 @@ export function available(mod : string){
 
 export function ResponseEnded(span, response, responseEndArgs) {
     try { // this call happens within a SafeExecuteInTheMiddle;
-          // a raised exception will prevent the original resp.apply.end from being applied
-          // which would cause some of the response not to write to client
-        if(span) {
+        // a raised exception will prevent the original resp.apply.end from being applied
+        // which would cause some of the response not to write to client
+        if (span) {
             // @ts-ignore
             if (span.inHtCaptureScope != true) {
                 // @ts-ignore
@@ -30,7 +31,9 @@ export function ResponseEnded(span, response, responseEndArgs) {
                         Config.getInstance().config.data_capture.body_max_processing_size_bytes)
                     // the response may have been chunked during send & nested end call;
                     // if so & content lengths are the same, we already captured entire body
-                    if(response.get('Content-Length') == bodyCapture.getContentLength().toString()) { return }
+                    if (response.get('Content-Length') == bodyCapture.getContentLength().toString()) {
+                        return
+                    }
                     bodyCapture.appendData(responseEndArgs[0])
                     span.setAttribute('http.response.body', bodyCapture.dataString())
                 }
@@ -42,22 +45,22 @@ export function ResponseEnded(span, response, responseEndArgs) {
 
 }
 
-function ResponseCaptureWithConfig(config : any) : Function {
-    return function (original : Function) {
+function ResponseCaptureWithConfig(config: any): Function {
+    return function (original: Function) {
         const responseBodyEnabled = config.config.data_capture.http_body.response
         const maxCaptureSize = config.config.data_capture.body_max_size_bytes
-        return function(){
+        return function () {
             let capturedChunk = false
             let span = trace.getSpan(context.active())
-            if(responseBodyEnabled) {
-                if(span) {
+            if (responseBodyEnabled) {
+                if (span) {
                     // @ts-ignore
                     if (span.inHtCaptureScope != true) {
                         // @ts-ignore
-                        let headerContentType =  this.get('Content-Type')
-                        if(HttpInstrumentationWrapper.isRecordableContentType(headerContentType)) {
+                        let headerContentType = this.get('Content-Type')
+                        if (HttpInstrumentationWrapper.isRecordableContentType(headerContentType)) {
                             // @ts-ignore
-                            if(!span.hypertraceBodyCapture) {
+                            if (!span.hypertraceBodyCapture) {
                                 // @ts-ignore
                                 span.hypertraceBodyCapture = new BodyCapture(Config.getInstance().config.data_capture.body_max_size_bytes,
                                     Config.getInstance().config.data_capture.body_max_processing_size_bytes)
@@ -75,7 +78,7 @@ function ResponseCaptureWithConfig(config : any) : Function {
             // in that case we dont want to enter scope until we have captured
             // @ts-ignore
             span.inHtCaptureScope = capturedChunk;
-            let ret =  original.apply(this, arguments)
+            let ret = original.apply(this, arguments)
             // @ts-ignore
             span.inHtCaptureScope = false;
             return ret
@@ -83,11 +86,12 @@ function ResponseCaptureWithConfig(config : any) : Function {
     }
 }
 
-export function patchExpress(){
-    if(!available('express') || patched){
+export function patchExpress() {
+    if (!available('express') || patched) {
         return
     }
     patched = true
     const express = require('express')
+
     shimmer.wrap(express.response, 'send', ResponseCaptureWithConfig(Config.getInstance()))
 }

--- a/test/instrumentation/NoMiddlewareTest.ts
+++ b/test/instrumentation/NoMiddlewareTest.ts
@@ -60,6 +60,28 @@ describe('Simple app without middleware', () => {
             Registry.instance = undefined
         })
 
+        it('will return a 403 if a header filter returns true', async() => {
+            await httpRequest.post({
+                    host: 'localhost',
+                    port: 8000,
+                    path: '/test_post',
+                    headers: {
+                        'Content-Type': "application/json",
+                        'x-filter-test': 'true'
+                    }
+                },
+                JSON.stringify({"test": "valid-body"}))
+            let spans = agentTestWrapper.getSpans()
+            expect(spans.length).to.equal(2)
+            let serverSpan = spans[0]
+            expect(serverSpan.attributes['http.status_code']).to.equal(403)
+            expect(serverSpan.attributes['http.status_text']).to.equal('FORBIDDEN')
+
+            let requestSpan = spans[1]
+            expect(requestSpan.attributes['http.status_code']).to.equal(403)
+            expect(requestSpan.attributes['http.status_text']).to.equal('FORBIDDEN')
+        })
+
         it('will return a 403 if a body filter returns true', async() => {
         await httpRequest.post({
                 host: 'localhost',

--- a/test/instrumentation/NoMiddlewareTest.ts
+++ b/test/instrumentation/NoMiddlewareTest.ts
@@ -1,0 +1,108 @@
+import {AgentForTest} from "./AgentForTest";
+
+const agentTestWrapper = AgentForTest.getInstance()
+agentTestWrapper.instrument()
+
+import {expect} from "chai";
+import * as http from "http";
+import {httpRequest} from "./HttpRequest";
+import {Registry} from "../../src/filter/Registry";
+import {SampleFilter} from "./SampleFilter";
+import {Framework} from "../../src/instrumentation/Framework";
+
+
+describe('Simple app without middleware', () => {
+    const express = require('express');
+
+    const app = express();
+
+    // app.use(body-parser)
+    // app.use(express.json)
+    // note the lack of any body parsing middleware
+
+    app.post('/test_post', (req : any, res: any) => {
+        let str = ''
+        req.on('data', (chunk) => {
+            str += chunk;
+        })
+
+        req.on('end', () => {
+            res.setHeader("Content-Type", "application/json");
+            res.send(str);
+        })
+    })
+
+    let server = http.createServer(app)
+    let originalImpl = Framework.getInstance().isPureExpress
+
+    before((done)=> {
+        Framework.getInstance().isPureExpress = () => {return true}
+        server.listen(8000)
+        server.on('listening', () => {done()})
+    })
+
+    afterEach( ()=> {
+        agentTestWrapper.stop()
+    })
+
+    after(()=> {
+        Framework.getInstance().isPureExpress = originalImpl
+        server.close()
+    })
+
+    describe('filter api', () => {
+        before(() => {
+            Registry.getInstance().register(new SampleFilter())
+        })
+
+        after(() => {
+            // @ts-ignore
+            Registry.instance = undefined
+        })
+
+        it('will return a 403 if a body filter returns true', async() => {
+        await httpRequest.post({
+                host: 'localhost',
+                port: 8000,
+                path: '/test_post',
+                headers: {
+                    'Content-Type': "application/json",
+                }
+            },
+            JSON.stringify({"test": "block-this-body"}))
+            let spans = agentTestWrapper.getSpans()
+            expect(spans.length).to.equal(2)
+            let serverSpan = spans[0]
+            expect(serverSpan.attributes['http.status_code']).to.equal(403)
+            expect(serverSpan.attributes['http.status_text']).to.equal('FORBIDDEN')
+
+            let requestSpan = spans[1]
+            expect(requestSpan.attributes['http.status_code']).to.equal(403)
+            expect(requestSpan.attributes['http.status_text']).to.equal('FORBIDDEN')
+        })
+
+        it('will return normal response if not filtered', async() => {
+            await httpRequest.post({
+                    host: 'localhost',
+                    port: 8000,
+                    path: '/test_post',
+                    headers: {
+                        'Content-Type': "application/json",
+                    }
+                },
+                JSON.stringify({"test": "valid"}))
+
+
+            let spans = agentTestWrapper.getSpans()
+            expect(spans.length).to.equal(2)
+            let serverSpan = spans[0]
+            expect(serverSpan.attributes['http.status_code']).to.equal(200)
+            expect(serverSpan.attributes['http.status_text']).to.equal('OK')
+
+            let requestSpan = spans[1]
+            expect(requestSpan.attributes['http.status_code']).to.equal(200)
+            expect(requestSpan.attributes['http.status_text']).to.equal('OK')
+        })
+
+    })
+});


### PR DESCRIPTION
## Description

The crux of the issue is our body capture depends on listening for 2 request events: 
1.) data (a chunk of data)
2.) end (indicates no more data will be written)

If a user app also leverages those 2 events we get into an issue where essentially this is occuring: 
```
our_data_event
user_data_event

our_end_event
user_end_event
```

The events are occuring async, so if our end event propagates an uncaught error, the node process will crash(since "outside" req handler)

Even if our end event runs first(we can't modify the other listeners to be noops) through something roughly like: 
```
// pseudocode(but attempted this route:( )
// listeners = req.listeners('end')
//for i < listener.length:
// req.listeners('end')[i] = () => {}
```
because the listener handlers are already being executed from the async lib. 

I tried a few other things, like using the 'raw-body' package to read the body sync, however, that is problematic for a few reasons: 
1.) we dont know what body settings a user would apply(like size limits, etc) so we'd have to us placeholders which may not match end user app expectations. (no reason to parse a body larger than the app itself would accept, or limit it too small)

2.) library is promise based(which essentially just gets us back to the event issue) or use async await; however,  since this is occuring so deep in the otel/ht agent, we'd have to update a mountain of the stack with a bunch of async/await(unfeasible) 

I also tried wrapping express app create to always inject an error handler; that doesn't quite work because we don't have a good way to inject the error handler **at the end** of the express middleware chain. 


The solution i ended up going with was leveraging domains 
https://nodejs.org/api/domain.html

I added a test app that does not include any middleware and it now successfully returns 403 forbidden. 
I did not migrate all frameworks to use domains because the domain feature is long deprecated(with no replacement as of today)
(leveraging domain was a last resort since it is deprecated; however, I've racked my brain trying to come up with different solutions & none beside this proved fruitful)
 