### PR TITLE
Support plain http server

### DIFF
--- a/src/instrumentation/HttpInstrumentationWrapper.ts
+++ b/src/instrumentation/HttpInstrumentationWrapper.ts
@@ -178,6 +178,18 @@ export class HttpInstrumentationWrapper {
                 span.setAttribute("http.response.body", bodyString);
             });
         }
+        if (response instanceof ServerResponse) {
+            let bodyCapture = new BodyCapture(<number>Config.getInstance().config.data_capture.body_max_size_bytes, 0);
+            const listener = (chunk: any) => {
+                bodyCapture.appendData(chunk);
+            };
+            response.on("data", listener);
+            response.once("end", () => {
+                response.removeListener('data', listener);
+                let bodyString = bodyCapture.dataString();
+                span.setAttribute("http.response.body", bodyString);
+            });
+        }
 
     }
 

--- a/src/instrumentation/HttpInstrumentationWrapper.ts
+++ b/src/instrumentation/HttpInstrumentationWrapper.ts
@@ -178,6 +178,7 @@ export class HttpInstrumentationWrapper {
                 span.setAttribute("http.response.body", bodyString);
             });
         }
+
     }
 
     RespHook = this.respHook.bind(this)

--- a/src/instrumentation/HttpInstrumentationWrapper.ts
+++ b/src/instrumentation/HttpInstrumentationWrapper.ts
@@ -178,19 +178,6 @@ export class HttpInstrumentationWrapper {
                 span.setAttribute("http.response.body", bodyString);
             });
         }
-        if (response instanceof ServerResponse) {
-            let bodyCapture = new BodyCapture(<number>Config.getInstance().config.data_capture.body_max_size_bytes, 0);
-            const listener = (chunk: any) => {
-                bodyCapture.appendData(chunk);
-            };
-            response.on("data", listener);
-            response.once("end", () => {
-                response.removeListener('data', listener);
-                let bodyString = bodyCapture.dataString();
-                span.setAttribute("http.response.body", bodyString);
-            });
-        }
-
     }
 
     RespHook = this.respHook.bind(this)

--- a/src/instrumentation/wrapper/ExpressWrapper.ts
+++ b/src/instrumentation/wrapper/ExpressWrapper.ts
@@ -24,14 +24,14 @@ export function ResponseEnded(span, response, responseEndArgs) {
             // @ts-ignore
             if (span.inHtCaptureScope != true) {
                 // @ts-ignore
-                let headerContentType = response.get('Content-Type')
+                let headerContentType = response.getHeader('Content-Type')
                 if (HttpInstrumentationWrapper.isRecordableContentType(headerContentType)) {
                     // @ts-ignore
                     let bodyCapture: BodyCapture = span.hypertraceBodyCapture || new BodyCapture(Config.getInstance().config.data_capture.body_max_size_bytes,
                         Config.getInstance().config.data_capture.body_max_processing_size_bytes)
                     // the response may have been chunked during send & nested end call;
                     // if so & content lengths are the same, we already captured entire body
-                    if (response.get('Content-Length') == bodyCapture.getContentLength().toString()) {
+                    if (response.getHeader('Content-Length') == bodyCapture.getContentLength().toString()) {
                         return
                     }
                     bodyCapture.appendData(responseEndArgs[0])

--- a/test/instrumentation/HttpTest.ts
+++ b/test/instrumentation/HttpTest.ts
@@ -8,9 +8,20 @@ import {httpRequest} from "./HttpRequest";
 
 describe('Agent tests', () => {
     const requestListener = function (req, res) {
-        res.setHeader("Content-Type", "application/json")
-        res.writeHead(200);
-        res.end(`{"test": "data"}`);
+        let body = ''
+        if(req.method == "POST") {
+            req.on('data', (data) => {body += data})
+            req.on('end', (data) => {
+                body += data
+                res.setHeader("Content-Type", "application/json")
+                res.writeHead(200);
+                res.end(`{"test post": "data"}`);
+            })
+        } else {
+            res.setHeader("Content-Type", "application/json")
+            res.writeHead(200);
+            res.end(`{"test": "data"}`);
+        }
     }
 
     let server = http.createServer(requestListener)
@@ -33,19 +44,19 @@ describe('Agent tests', () => {
         const response = await httpRequest.get('http://localhost:8000/')
         let spans = agentTestWrapper.getSpans()
         expect(spans.length).to.equal(2)
-        let requestSpanAttributes = spans[0].attributes
-        expect(requestSpanAttributes['http.method']).to.equal('GET')
-        expect(requestSpanAttributes['net.host.name']).to.equal('localhost')
-        expect(requestSpanAttributes['http.target']).to.equal('/')
-        expect(requestSpanAttributes['net.transport']).to.equal('ip_tcp')
-        expect(requestSpanAttributes['http.status_code']).to.equal(200)
-
-        let serverSpanAttributes = spans[1].attributes
+        let serverSpanAttributes = spans[0].attributes
         expect(serverSpanAttributes['http.method']).to.equal('GET')
-        expect(serverSpanAttributes['net.peer.name']).to.equal('localhost')
+        expect(serverSpanAttributes['net.host.name']).to.equal('localhost')
         expect(serverSpanAttributes['http.target']).to.equal('/')
         expect(serverSpanAttributes['net.transport']).to.equal('ip_tcp')
         expect(serverSpanAttributes['http.status_code']).to.equal(200)
+
+        let requestSpanAttributes = spans[1].attributes
+        expect(requestSpanAttributes['http.method']).to.equal('GET')
+        expect(requestSpanAttributes['net.peer.name']).to.equal('localhost')
+        expect(requestSpanAttributes['http.target']).to.equal('/')
+        expect(requestSpanAttributes['net.transport']).to.equal('ip_tcp')
+        expect(requestSpanAttributes['http.status_code']).to.equal(200)
         expect(spans[1].name).to.equal('HTTP GET')
     });
 
@@ -53,11 +64,11 @@ describe('Agent tests', () => {
         const response = await httpRequest.get('http://localhost:8000/')
         let spans = agentTestWrapper.getSpans()
         expect(spans.length).to.equal(2)
-        let requestSpanAttributes = spans[0].attributes
-        expect(requestSpanAttributes['http.response.body']).to.equal(`{"test": "data"}`)
-
-        let serverSpanAttributes = spans[1].attributes
+        let serverSpanAttributes = spans[0].attributes
         expect(serverSpanAttributes['http.response.body']).to.equal(`{"test": "data"}`)
+
+        let requestSpanAttributes = spans[1].attributes
+        expect(requestSpanAttributes['http.response.body']).to.equal(`{"test": "data"}`)
     });
 
     it('can capture request body data', async () => {
@@ -66,6 +77,7 @@ describe('Agent tests', () => {
                 port: 8000,
                 path: '/',
                 headers: {
+                    "Some-Header": "Foo-Bar",
                     "Content-Type": "application/json"
                 }
             },
@@ -73,11 +85,11 @@ describe('Agent tests', () => {
         )
         let spans = agentTestWrapper.getSpans()
         expect(spans.length).to.equal(2)
-        let requestSpanAttributes = spans[0].attributes
-        expect(requestSpanAttributes['http.response.body']).to.equal(`{"test": "data"}`)
+        let serverSpanAttributes = spans[0].attributes
+        expect(serverSpanAttributes['http.request.body']).to.equal(`{"data":"123"}`)
 
-        let serverSpanAttributes = spans[1].attributes
-        expect(serverSpanAttributes['http.response.body']).to.equal(`{"test": "data"}`)
+        let requestSpanAttributes = spans[1].attributes
+        expect(requestSpanAttributes['http.request.body']).to.equal(`{"data":"123"}`)
     });
 
 

--- a/test/instrumentation/HttpTest.ts
+++ b/test/instrumentation/HttpTest.ts
@@ -1,0 +1,84 @@
+import {AgentForTest} from "./AgentForTest";
+const agentTestWrapper = AgentForTest.getInstance();
+agentTestWrapper.instrument()
+
+import {expect} from "chai";
+import * as http from "http";
+import {httpRequest} from "./HttpRequest";
+
+describe('Agent tests', () => {
+    const requestListener = function (req, res) {
+        res.setHeader("Content-Type", "application/json")
+        res.writeHead(200);
+        res.end(`{"test": "data"}`);
+    }
+
+    let server = http.createServer(requestListener)
+
+    before((done)=> {
+        server.listen(8000)
+        server.on('listening', () => {done()})
+    })
+
+    afterEach(() => {
+        agentTestWrapper.stop()
+    })
+
+    after( ()=> {
+        server.close()
+        agentTestWrapper.stop()
+    })
+
+    it('can capture spans', async () => {
+        const response = await httpRequest.get('http://localhost:8000/')
+        let spans = agentTestWrapper.getSpans()
+        expect(spans.length).to.equal(2)
+        let requestSpanAttributes = spans[0].attributes
+        expect(requestSpanAttributes['http.method']).to.equal('GET')
+        expect(requestSpanAttributes['net.host.name']).to.equal('localhost')
+        expect(requestSpanAttributes['http.target']).to.equal('/')
+        expect(requestSpanAttributes['net.transport']).to.equal('ip_tcp')
+        expect(requestSpanAttributes['http.status_code']).to.equal(200)
+
+        let serverSpanAttributes = spans[1].attributes
+        expect(serverSpanAttributes['http.method']).to.equal('GET')
+        expect(serverSpanAttributes['net.peer.name']).to.equal('localhost')
+        expect(serverSpanAttributes['http.target']).to.equal('/')
+        expect(serverSpanAttributes['net.transport']).to.equal('ip_tcp')
+        expect(serverSpanAttributes['http.status_code']).to.equal(200)
+        expect(spans[1].name).to.equal('HTTP GET')
+    });
+
+    it('can capture response body data', async () => {
+        const response = await httpRequest.get('http://localhost:8000/')
+        let spans = agentTestWrapper.getSpans()
+        expect(spans.length).to.equal(2)
+        let requestSpanAttributes = spans[0].attributes
+        expect(requestSpanAttributes['http.response.body']).to.equal(`{"test": "data"}`)
+
+        let serverSpanAttributes = spans[1].attributes
+        expect(serverSpanAttributes['http.response.body']).to.equal(`{"test": "data"}`)
+    });
+
+    it('can capture request body data', async () => {
+        const response = await httpRequest.post({
+                host: 'localhost',
+                port: 8000,
+                path: '/',
+                headers: {
+                    "Content-Type": "application/json"
+                }
+            },
+            JSON.stringify({data: "123"})
+        )
+        let spans = agentTestWrapper.getSpans()
+        expect(spans.length).to.equal(2)
+        let requestSpanAttributes = spans[0].attributes
+        expect(requestSpanAttributes['http.response.body']).to.equal(`{"test": "data"}`)
+
+        let serverSpanAttributes = spans[1].attributes
+        expect(serverSpanAttributes['http.response.body']).to.equal(`{"test": "data"}`)
+    });
+
+
+});


### PR DESCRIPTION
## Description
- Update header retrieval to use `getHeader` instead of `get`
https://nodejs.org/api/http.html#responsegetheader

- Add tests