### PR TITLE
fix: update instrumentation to account for plain http server

### DIFF
--- a/src/instrumentation/Framework.ts
+++ b/src/instrumentation/Framework.ts
@@ -31,6 +31,10 @@ export class Framework {
         return (this.frameworks['sails'] || this.frameworks['nestjs'])
     }
 
+    public noFrameworks = () => {
+        return(this.frameworks['sails'] || this.frameworks['nestjs'] || this.frameworks['koa'] || this.frameworks['hapi'] || this.frameworks['express'])
+    }
+
     available = (mod: string) => {
         try {
             require.resolve(mod)

--- a/src/instrumentation/HttpInstrumentationWrapper.ts
+++ b/src/instrumentation/HttpInstrumentationWrapper.ts
@@ -75,7 +75,7 @@ export class HttpInstrumentationWrapper {
             let bodyCapture: BodyCapture = new BodyCapture(<number>Config.getInstance().config.data_capture!.body_max_size_bytes!,
                 <number>Config.getInstance().config.data_capture!.body_max_processing_size_bytes!)
             if (this.shouldCaptureBody(<boolean>Config.getInstance().config.data_capture!.http_body!.request!, headers)) {
-                if (request.hasOwnProperty("res") || Framework.getInstance().isExpressBased()) { // this means we are in a express based app
+                if (Framework.getInstance().noFrameworks() || Framework.getInstance().isExpressBased() || Framework.getInstance().isPureExpress()) {
                     const listener = (chunk: any) => {
                         bodyCapture.appendData(chunk)
                     }

--- a/test/instrumentation/HapiTest.ts
+++ b/test/instrumentation/HapiTest.ts
@@ -13,7 +13,7 @@ import {REQUEST_TYPE} from "../../lib/filter/Filter";
 import {isCompatible} from "../../lib/instrumentation/InstrumentationCompat";
 import {Framework} from "../../src/instrumentation/Framework";
 
-if(isCompatible("12.0.0") === true){
+//if(isCompatible("12.0.0") === true){
     const Hapi = require('@hapi/hapi');
 
     describe('Hapi tests', () => {
@@ -47,9 +47,13 @@ if(isCompatible("12.0.0") === true){
             }
         });
 
-        let original = Framework.getInstance().isExpressBased
+        let expressBased = Framework.getInstance().isExpressBased
+        let onlyExpress = Framework.getInstance().isPureExpress
+        let noFrameworks = Framework.getInstance().noFrameworks
         before(async ()=> {
             Framework.getInstance().isExpressBased = () => {return false}
+            Framework.getInstance().isPureExpress =  () => {return false}
+            Framework.getInstance().noFrameworks = () => {return false}
             await server.start();
         })
 
@@ -58,7 +62,9 @@ if(isCompatible("12.0.0") === true){
         })
 
         after( ()=> {
-            Framework.getInstance().isExpressBased = original
+            Framework.getInstance().isExpressBased = expressBased
+            Framework.getInstance().isPureExpress = onlyExpress
+            Framework.getInstance().isPureExpress = noFrameworks
             server.stop()
             agentTestWrapper.stop()
         })
@@ -249,4 +255,4 @@ if(isCompatible("12.0.0") === true){
 
 
     });
-}
+//}

--- a/test/instrumentation/HapiTest.ts
+++ b/test/instrumentation/HapiTest.ts
@@ -13,7 +13,7 @@ import {REQUEST_TYPE} from "../../lib/filter/Filter";
 import {isCompatible} from "../../lib/instrumentation/InstrumentationCompat";
 import {Framework} from "../../src/instrumentation/Framework";
 
-//if(isCompatible("12.0.0") === true){
+if(isCompatible("12.0.0") === true){
     const Hapi = require('@hapi/hapi');
 
     describe('Hapi tests', () => {
@@ -255,4 +255,4 @@ import {Framework} from "../../src/instrumentation/Framework";
 
 
     });
-//}
+}

--- a/test/instrumentation/HttpTest.ts
+++ b/test/instrumentation/HttpTest.ts
@@ -5,6 +5,7 @@ agentTestWrapper.instrument()
 import {expect} from "chai";
 import * as http from "http";
 import {httpRequest} from "./HttpRequest";
+import {Framework} from "../../src/instrumentation/Framework";
 
 describe('Agent tests', () => {
     const requestListener = function (req, res) {
@@ -25,8 +26,14 @@ describe('Agent tests', () => {
     }
 
     let server = http.createServer(requestListener)
-
+    let originalIncludeExpress = Framework.getInstance().isExpressBased
+    let originalOnlyExpress = Framework.getInstance().isExpressBased
+    let originalNoFrameworks = Framework.getInstance().noFrameworks
     before((done)=> {
+        Framework.getInstance().isExpressBased = () => {return false}
+        Framework.getInstance().isPureExpress = () => {return false}
+        Framework.getInstance().noFrameworks = () => {return true}
+
         server.listen(8000)
         server.on('listening', () => {done()})
     })
@@ -36,6 +43,9 @@ describe('Agent tests', () => {
     })
 
     after( ()=> {
+        Framework.getInstance().isExpressBased = originalIncludeExpress
+        Framework.getInstance().isPureExpress = originalOnlyExpress
+        Framework.getInstance().noFrameworks = originalNoFrameworks
         server.close()
         agentTestWrapper.stop()
     })

--- a/test/instrumentation/KoaTest.ts
+++ b/test/instrumentation/KoaTest.ts
@@ -30,9 +30,13 @@ describe('Koa tests', () => {
     let server : any;
     // We need to do this since all our tests run in the same process
     // otherwise even though we are testing koa, express is still present in the node_modules
-    let original = Framework.getInstance().isExpressBased
+    let expressBased = Framework.getInstance().isExpressBased
+    let onlyExpress = Framework.getInstance().isPureExpress
+    let noFrameworks = Framework.getInstance().noFrameworks
     before(()=> {
         Framework.getInstance().isExpressBased = () => {return false}
+        Framework.getInstance().isPureExpress =  () => {return false}
+        Framework.getInstance().noFrameworks = () => {return false}
         server = app.listen(8000)
     })
 
@@ -41,7 +45,9 @@ describe('Koa tests', () => {
     })
 
     after(()=> {
-        Framework.getInstance().isExpressBased = original
+        Framework.getInstance().isExpressBased = expressBased
+        Framework.getInstance().isPureExpress = onlyExpress
+        Framework.getInstance().isPureExpress = noFrameworks
         server.close()
     })
 


### PR DESCRIPTION
In the case of no frameworks we need to do body capture the same way we do express based capture.  
This check also prevented graphql body capture.