### PR TITLE
fix: plain http server detection & hapi response body capture 

### DIFF
--- a/src/HypertraceAgent.ts
+++ b/src/HypertraceAgent.ts
@@ -34,6 +34,7 @@ import {HttpHypertraceInstrumentation} from "./instrumentation/HttpHypertraceIns
 import {patchSails} from "./instrumentation/wrapper/SailsWrapper";
 import {Framework} from "./instrumentation/Framework";
 import {LambdaRequestHook, LambdaResponseHook} from "./instrumentation/LambdaInstrumentationWrapper";
+import {patchHapi} from "./instrumentation/wrapper/HapiWrapper";
 const api = require("@opentelemetry/api");
 
 const {Resource} = require('@opentelemetry/resources');
@@ -110,6 +111,7 @@ export class HypertraceAgent {
         if(isCompatible("12.0.0")){
             // Imports are only allowed at top level
             // so instead we need to require it if the node version is modern enough
+            patchHapi()
             const hapiHypertraceInstrumentation = require("./instrumentation/HapiHypertraceInstrumentation")
             instrumentations.push(new hapiHypertraceInstrumentation.HapiHypertraceInstrumentation({}),)
         }

--- a/src/instrumentation/Framework.ts
+++ b/src/instrumentation/Framework.ts
@@ -3,7 +3,7 @@ export class Framework {
     public config: any
 
     private frameworks: Map<string, boolean>
-    static supportedFrameworks = ['express', 'koa', 'nestjs', 'sails', 'hapi']
+    static supportedFrameworks = ['express', 'koa', '@nestjs/core', 'sails', '@hapi/hapi']
 
     private constructor() {
         this.frameworks = new Map<string, boolean>()
@@ -24,15 +24,15 @@ export class Framework {
     // we can pass filter error up middleware chain cleanly from event based body read
     // if it is purely express, we need to end response immediately
     public isPureExpress = () => {
-        return !(this.frameworks['sails'] || this.frameworks['nestjs'] || this.frameworks['koa'] || this.frameworks['hapi']);
+        return !(this.frameworks['sails'] || this.frameworks['@nestjs/core'] || this.frameworks['koa'] || this.frameworks['@hapi/hapi']);
     }
 
     public isExpressBased = () => {
-        return (this.frameworks['sails'] || this.frameworks['nestjs'])
+        return (this.frameworks['sails'] || this.frameworks['@nestjs/core'])
     }
 
-    public noFrameworks = () => {
-        return(this.frameworks['sails'] || this.frameworks['nestjs'] || this.frameworks['koa'] || this.frameworks['hapi'] || this.frameworks['express'])
+    public anyFrameworks = () => {
+        return(this.frameworks['sails'] || this.frameworks['@nestjs/core'] || this.frameworks['koa'] || this.frameworks['@hapi/hapi'] || this.frameworks['express'])
     }
 
     available = (mod: string) => {

--- a/src/instrumentation/HapiHypertraceInstrumentation.ts
+++ b/src/instrumentation/HapiHypertraceInstrumentation.ts
@@ -45,7 +45,7 @@ import {
     isPatchableExtMethod,
     getRootSpanMetadata,
 } from '@opentelemetry/instrumentation-hapi/build/src/utils';
-import {captureResponse, captureWithFilter} from "./wrapper/HapiBodyCapture";
+import {captureWithFilter} from "./wrapper/HapiBodyCapture";
 
 /** Hapi instrumentation for OpenTelemetry */
 export class HapiHypertraceInstrumentation extends InstrumentationBase {
@@ -415,9 +415,7 @@ export class HapiHypertraceInstrumentation extends InstrumentationBase {
                     attributes: metadata.attributes,
                 });
                 try {
-                    let r =  await oldHandler(request, h, err);
-                    captureResponse(hapiSpan, h, r)
-                    return r
+                    return await oldHandler(request, h, err);
                 } catch (err) {
                     span.recordException(err);
                     span.setStatus({

--- a/src/instrumentation/HttpInstrumentationWrapper.ts
+++ b/src/instrumentation/HttpInstrumentationWrapper.ts
@@ -75,7 +75,7 @@ export class HttpInstrumentationWrapper {
             let bodyCapture: BodyCapture = new BodyCapture(<number>Config.getInstance().config.data_capture!.body_max_size_bytes!,
                 <number>Config.getInstance().config.data_capture!.body_max_processing_size_bytes!)
             if (this.shouldCaptureBody(<boolean>Config.getInstance().config.data_capture!.http_body!.request!, headers)) {
-                if (Framework.getInstance().noFrameworks() || Framework.getInstance().isExpressBased() || Framework.getInstance().isPureExpress()) {
+                if (!Framework.getInstance().anyFrameworks() || Framework.getInstance().isExpressBased() || Framework.getInstance().isPureExpress()) {
                     const listener = (chunk: any) => {
                         bodyCapture.appendData(chunk)
                     }
@@ -196,7 +196,7 @@ export class HttpInstrumentationWrapper {
     }
 
     public static isRecordableContentType(contentType?: string): boolean {
-        if (contentType === undefined) {
+        if (contentType === undefined || contentType === null) {
             return false
         }
         for (let recordableType of _RECORDABLE_CONTENT_TYPES) {

--- a/src/instrumentation/wrapper/HapiWrapper.ts
+++ b/src/instrumentation/wrapper/HapiWrapper.ts
@@ -1,0 +1,58 @@
+import {Framework} from "../Framework";
+import {context, trace} from "@opentelemetry/api";
+import {HttpInstrumentationWrapper} from "../HttpInstrumentationWrapper";
+import {BodyCapture} from "../BodyCapture";
+import {Config} from "../../config/config";
+
+let patched = false
+const shimmer = require('shimmer');
+
+function HapiWrapWithConfig(config: any): Function {
+    return function (original: Function) {
+        const responseBodyEnabled = config.config.data_capture.http_body.response
+        const maxCaptureSize = config.config.data_capture.body_max_size_bytes
+        return function () {
+            let result = arguments[0]
+            let request = arguments[1]
+
+            // Ret is a wrapped hapi response object
+            let ret = original.apply(this, arguments)
+
+            // if our capture fails just return original response
+            try {
+                if (responseBodyEnabled) {
+                    let capturedChunk = false
+                    let span = trace.getSpan(context.active())
+                    // @ts-ignore
+                    if (span && !span.hapiAlreadyCaptured) {
+                        // @ts-ignore
+                        let headerContentType = ret._contentType
+                        if (HttpInstrumentationWrapper.isRecordableContentType(headerContentType)) {
+                            // @ts-ignore
+                            span.hapiAlreadyCaptured = true
+                            // @ts-ignore
+                            let bodyCapture = new BodyCapture(Config.getInstance().config.data_capture.body_max_size_bytes,
+                                Config.getInstance().config.data_capture.body_max_processing_size_bytes)
+                            bodyCapture.appendData(result)
+                            // @ts-ignore
+                            span.setAttribute('http.response.body', bodyCapture.dataString())
+                        }
+                    }
+                }
+            } catch {
+                return ret
+            }
+            return ret
+        }
+    }
+}
+
+export function patchHapi() {
+    if (!Framework.getInstance().available('@hapi/hapi') || patched) {
+        return
+    }
+    patched = true
+    const hapiResponse = require('@hapi/hapi/lib/response')
+
+    shimmer.wrap(hapiResponse, 'wrap', HapiWrapWithConfig(Config.getInstance()))
+}

--- a/test/instrumentation/HapiTest.ts
+++ b/test/instrumentation/HapiTest.ts
@@ -49,11 +49,11 @@ if(isCompatible("12.0.0") === true){
 
         let expressBased = Framework.getInstance().isExpressBased
         let onlyExpress = Framework.getInstance().isPureExpress
-        let noFrameworks = Framework.getInstance().noFrameworks
+        let anyFrameworks = Framework.getInstance().anyFrameworks
         before(async ()=> {
             Framework.getInstance().isExpressBased = () => {return false}
             Framework.getInstance().isPureExpress =  () => {return false}
-            Framework.getInstance().noFrameworks = () => {return false}
+            Framework.getInstance().anyFrameworks = () => {return true}
             await server.start();
         })
 
@@ -64,7 +64,7 @@ if(isCompatible("12.0.0") === true){
         after( ()=> {
             Framework.getInstance().isExpressBased = expressBased
             Framework.getInstance().isPureExpress = onlyExpress
-            Framework.getInstance().isPureExpress = noFrameworks
+            Framework.getInstance().isPureExpress = anyFrameworks
             server.stop()
             agentTestWrapper.stop()
         })

--- a/test/instrumentation/HttpTest.ts
+++ b/test/instrumentation/HttpTest.ts
@@ -28,11 +28,11 @@ describe('Agent tests', () => {
     let server = http.createServer(requestListener)
     let originalIncludeExpress = Framework.getInstance().isExpressBased
     let originalOnlyExpress = Framework.getInstance().isExpressBased
-    let originalNoFrameworks = Framework.getInstance().noFrameworks
+    let originalanyFrameworks = Framework.getInstance().anyFrameworks
     before((done)=> {
         Framework.getInstance().isExpressBased = () => {return false}
         Framework.getInstance().isPureExpress = () => {return false}
-        Framework.getInstance().noFrameworks = () => {return true}
+        Framework.getInstance().anyFrameworks = () => {return false}
         server.listen(8000)
         server.on('listening', () => {done()})
     })
@@ -44,7 +44,7 @@ describe('Agent tests', () => {
     after( ()=> {
         Framework.getInstance().isExpressBased = originalIncludeExpress
         Framework.getInstance().isPureExpress = originalOnlyExpress
-        Framework.getInstance().noFrameworks = originalNoFrameworks
+        Framework.getInstance().anyFrameworks = originalanyFrameworks
         server.close()
         agentTestWrapper.stop()
     })

--- a/test/instrumentation/KoaTest.ts
+++ b/test/instrumentation/KoaTest.ts
@@ -32,11 +32,11 @@ describe('Koa tests', () => {
     // otherwise even though we are testing koa, express is still present in the node_modules
     let expressBased = Framework.getInstance().isExpressBased
     let onlyExpress = Framework.getInstance().isPureExpress
-    let noFrameworks = Framework.getInstance().noFrameworks
+    let anyFrameworks = Framework.getInstance().anyFrameworks
     before(()=> {
         Framework.getInstance().isExpressBased = () => {return false}
         Framework.getInstance().isPureExpress =  () => {return false}
-        Framework.getInstance().noFrameworks = () => {return false}
+        Framework.getInstance().anyFrameworks = () => {return true}
         server = app.listen(8000)
     })
 
@@ -47,7 +47,7 @@ describe('Koa tests', () => {
     after(()=> {
         Framework.getInstance().isExpressBased = expressBased
         Framework.getInstance().isPureExpress = onlyExpress
-        Framework.getInstance().isPureExpress = noFrameworks
+        Framework.getInstance().isPureExpress = anyFrameworks
         server.close()
     })
 


### PR DESCRIPTION
# Description
- Update hapi response capture to occur after the route result is wrapped in a hapi response object
- Update plain http server to capture response data based on lack of presence of any framework
- Update framework library detection names for hapi & nestjs