### PR TITLE
fix: only set capture scope if span is available

### DIFF
--- a/src/instrumentation/wrapper/ExpressWrapper.ts
+++ b/src/instrumentation/wrapper/ExpressWrapper.ts
@@ -80,11 +80,15 @@ function ResponseCaptureWithConfig(config: any): Function {
             }
             // sometimes we can't capture a chunk at a certain scope because content-type isn't set yet,
             // in that case we dont want to enter scope until we have captured
-            // @ts-ignore
-            span.inHtCaptureScope = capturedChunk;
+            if(span){
+                // @ts-ignore
+                span.inHtCaptureScope = capturedChunk;
+            }
             let ret = original.apply(this, arguments)
-            // @ts-ignore
-            span.inHtCaptureScope = false;
+            if(span){
+                // @ts-ignore
+                span.inHtCaptureScope = false;
+            }
             return ret
         }
     }


### PR DESCRIPTION
## Description
If a span is not available we should not attempt to set inHtCaptureScope before calling into the original function.