### PR TITLE
chore: update max_processing_size default. Update readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ _Note: Using npm link doesnt solve the local testing problem as it will use the 
     1. Start external services
         ```
         cd ./test/externalServices
-        docker-compuse up -d
+        docker-compose up -d
         cd -
         ```
     1. 
@@ -58,7 +58,7 @@ _Note: Using npm link doesnt solve the local testing problem as it will use the 
     1. Stop external services if not needed.
         ```
         cd ./test/externalServices
-        docker-compuse down
+        docker-compose down
         cd -
         ```
 

--- a/README.md
+++ b/README.md
@@ -6,35 +6,70 @@
 
 ## Development
 
-### Developing locally
-Then run: `npm run build`, you can then install the generated .tgz as a normal dependency.
+### Building
+1.  Update protobuf definitions
+    1. Update the `agent-config` submodule.
+        ```
+        git submodule update --init --recursive
+        ```
+    1. Generate protobbuf files: `./src/instrumentation/config/generated.js` and  `./src/instrumentation/config.generated.d.ts`.
+        ```
+        npm run generate_pb
+        ```
+1. Build.
+    ```
+    npm run build
+    ```
+
+You can then install the generated .tgz as a normal dependency.
 
 _Note: Using npm link doesnt solve the local testing problem as it will use the hypertrace package dev-dependencies during instrumentation instead of the targetted node app_
 
-You can then run or debug the example application in the `examples` directory. 
 
-### Updating protobuf definitions
-If you want to update the protobuf definitions, first update the `agent-config` submodule.
-ex: `git submodule update --init --recursive`
 
-You can then run `npm run generate_pb`
+### Testing
+* Run the example application
 
-This will generate two files: `./src/instrumentation/config/generated.js` & `./src/instrumentation/config.generated.d.ts`
+    1. 
+        ```
+        cd ./examples/correlation
+        ```
+    1. Update `config.yaml` if needed.
+    1. Install dependencies
+        ```
+        npm install
+        ```
+    1. Start application
+        ```
+        npm start
+        ```
 
-### Tests
-Tests should be added to the `test` directory, in a structure that matches that of the file you are attempting to test.
+* Unit tests
+    1. Start external services
+        ```
+        cd ./test/externalServices
+        docker-compuse up -d
+        cd -
+        ```
+    1. 
+        ```
+        npm run test
+        ```
+    1. Stop external services if not needed.
+        ```
+        cd ./test/externalServices
+        docker-compuse down
+        cd -
+        ```
 
-Ideally all functionality is testable in locally runnable unit-tests(as opposed to in a docker container), primarily for ease of debugging.
+    Tests should be added to the `test` directory, in a structure that matches that of the file you are attempting to test.
 
-You can run all tests with `npm run test`
+    Ideally all functionality is testable in locally runnable unit-tests(as opposed to in a docker container), primarily for ease of debugging.
 
-### Building lambda layer
+### Lambda layer
 To build the layer & upload it to an AWS account:
 
-1.) Run `npm install && npm run build`
-
-2.) Run `./build_layer.sh <REGION>` where region is the region you want the layer to be available in
-
-3.) Add an environment variable to your lambda: `AWS_LAMBDA_EXEC_WRAPPER=/opt/hypertrace-instrument`
-
-4.) Configure reporting to a collector, you can set `HT_REPORTING_ENDPOINT` to a valid OTLP collector address. - If using with a collector layer, no need to specify an OTLP address as it will export to localhost:4317
+1. Build using the steps above.
+1. Run `./build_layer.sh <REGION>` where region is the region you want the layer to be available in
+1. Add an environment variable to your lambda: `AWS_LAMBDA_EXEC_WRAPPER=/opt/hypertrace-instrument`
+1. Configure reporting to a collector, you can set `HT_REPORTING_ENDPOINT` to a valid OTLP collector address. - If using with a collector layer, no need to specify an OTLP address as it will export to localhost:4317

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -31,7 +31,7 @@ const DEFAULT_AGENT_CONFIG = {
             'response': true,
         },
         'body_max_size_bytes': 131072,
-        'body_max_processing_size_bytes': 1048576
+        'body_max_processing_size_bytes': 131072
     },
     'resource_attributes': {}
 }

--- a/test/config/configTest.ts
+++ b/test/config/configTest.ts
@@ -31,7 +31,7 @@ describe('Config tests', () => {
         expect(config.config.data_capture.rpc_body.request).to.equal(true)
         expect(config.config.data_capture.rpc_body.response).to.equal(true)
         expect(config.config.data_capture.body_max_size_bytes).to.equal(131072)
-        expect(config.config.data_capture.body_max_processing_size_bytes).to.equal(1048576)
+        expect(config.config.data_capture.body_max_processing_size_bytes).to.equal(131072)
 
         expect(config.config.resource_attributes).to.eql({})
     });


### PR DESCRIPTION
## Description
Update max_processing_size default to 128k.  This is consistent with other tracing agents.

### Testing
Ran example and unit tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

