### PR TITLE
grpc status + metadata updates

### DIFF
--- a/src/instrumentation/GrpcJsHypertraceClientUtils.ts
+++ b/src/instrumentation/GrpcJsHypertraceClientUtils.ts
@@ -73,10 +73,13 @@ export function makeGrpcClientRemoteCall(
                 });
             } else {
                 span.setStatus({ code: SpanStatusCode.UNSET });
-                span.setAttribute(
-                    SemanticAttributes.RPC_GRPC_STATUS_CODE,
-                    SpanStatusCode.OK.toString() // this wasn't matching server behavior of unset = Ok
-                );
+                span.setAttribute(SemanticAttributes.RPC_GRPC_STATUS_CODE, 0)
+                // This will set a SpanStatus=1 which is different from grpc status
+                // if no error, use grpc 0 for OK
+                // span.setAttribute(
+                //     SemanticAttributes.RPC_GRPC_STATUS_CODE,
+                //     SpanStatusCode.OK.toString() // this wasn't matching server behavior of unset = Ok
+                // );
             }
 
             span.end();

--- a/src/instrumentation/GrpcJsHypertraceInstrumentation.ts
+++ b/src/instrumentation/GrpcJsHypertraceInstrumentation.ts
@@ -315,7 +315,8 @@ export class GrpcJsHypertraceInstrumentation extends InstrumentationBase {
                 const span = instrumentation.tracer.startSpan(name, {
                     kind: SpanKind.CLIENT,
                 });
-
+                span.setAttribute("rpc.system", "grpc")
+                span.setAttribute("grpc.content_type", "application/grpc")
                 addMetadataToSpan(span, metadata, 'request')
                 createAndAddBodyCapture(span, args[0], 'request')
 

--- a/src/instrumentation/GrpcJsHypertraceServerUtils.ts
+++ b/src/instrumentation/GrpcJsHypertraceServerUtils.ts
@@ -134,10 +134,13 @@ function clientStreamAndUnaryHandler<RequestType, ResponseType>(
             });
         } else {
             span.setStatus({ code: SpanStatusCode.UNSET });
-            span.setAttribute(
-                SemanticAttributes.RPC_GRPC_STATUS_CODE,
-                SpanStatusCode.OK.toString()
-            );
+            span.setAttribute(SemanticAttributes.RPC_GRPC_STATUS_CODE, 0)
+            // This will set a SpanStatus which is different from grpc status
+            // if no error, use grpc 0 for OK
+            // span.setAttribute(
+            //     SemanticAttributes.RPC_GRPC_STATUS_CODE,
+            //     SpanStatusCode.OK.toString()
+            // );
         }
         createAndAddBodyCapture(span, value, 'response')
         span.end();

--- a/src/instrumentation/GrpcJsHypertraceServerUtils.ts
+++ b/src/instrumentation/GrpcJsHypertraceServerUtils.ts
@@ -142,6 +142,8 @@ function clientStreamAndUnaryHandler<RequestType, ResponseType>(
             //     SpanStatusCode.OK.toString()
             // );
         }
+        span.setAttribute("rpc.system", "grpc")
+        span.setAttribute("grpc.content_type", "application/grpc")
         createAndAddBodyCapture(span, value, 'response')
         span.end();
         return callback(err, value);

--- a/test/instrumentation/grpcjs/GrpcTest.ts
+++ b/test/instrumentation/grpcjs/GrpcTest.ts
@@ -91,6 +91,19 @@ describe('Grpc JS Support', () => {
             let csAttributes = spans[1].attributes
             expect(csAttributes['rpc.grpc.status_code']).to.equal(0)
         })
+
+        it('includes grpc indicator attributes',  () => {
+            let spans = agentTestWrapper.getSpans()
+            expect(spans.length).to.equal(2)
+
+            let ssAttributes = spans[0].attributes
+            expect(ssAttributes['rpc.system']).to.equal('grpc')
+            expect(ssAttributes['grpc.content_type']).to.equal('application/grpc')
+
+            let csAttributes = spans[1].attributes
+            expect(csAttributes['rpc.system']).to.equal('grpc')
+            expect(csAttributes['grpc.content_type']).to.equal('application/grpc')
+        })
     })
 
     describe('filter api', () => {

--- a/test/instrumentation/grpcjs/GrpcTest.ts
+++ b/test/instrumentation/grpcjs/GrpcTest.ts
@@ -86,10 +86,10 @@ describe('Grpc JS Support', () => {
             expect(spans.length).to.equal(2)
 
             let ssAttributes = spans[0].attributes
-            expect(ssAttributes['rpc.grpc.status_code']).to.equal("1")
+            expect(ssAttributes['rpc.grpc.status_code']).to.equal(0)
 
             let csAttributes = spans[1].attributes
-            expect(csAttributes['rpc.grpc.status_code']).to.equal("1")
+            expect(csAttributes['rpc.grpc.status_code']).to.equal(0)
         })
     })
 


### PR DESCRIPTION
## Description
For grpc if there was no error status code we were setting SpanStatus.OK which is 1, which equates to a grpc error. 

Instead if no error, we should use 0.

Previously metadata wouldn't appear in the platform even though we were collecting it because we weren't setting a rpc.system attribute