### PR TITLE
Handle non-api gateway events

### DIFF
--- a/src/instrumentation/LambdaInstrumentationWrapper.ts
+++ b/src/instrumentation/LambdaInstrumentationWrapper.ts
@@ -15,7 +15,6 @@ export function LambdaRequestHook(span, {event, context}){
         return
     }
 
-    logger.debug('Received lambda event', event);
     logger.debug('received lambda event')
     logger.debug(event)
 

--- a/src/instrumentation/LambdaInstrumentationWrapper.ts
+++ b/src/instrumentation/LambdaInstrumentationWrapper.ts
@@ -5,8 +5,17 @@ import {Config} from "../config/config";
 import {HttpInstrumentationWrapper} from "./HttpInstrumentationWrapper";
 
 export function LambdaRequestHook(span, {event, context}){
-    let headers = event['headers']
-    let lambdaRequestContext = event['requestContext']
+    const headers = event['headers'];
+    const lambdaRequestContext = event['requestContext'];
+
+    if(!headers || !lambdaRequestContext){
+        logger.warn("Received unexpected lambda event that doesnt look like an ApiGateway event")
+        logger.warn("Is the event an ApiGateway event?")
+        logger.warn(event)
+        return
+    }
+
+    logger.debug('Received lambda event', event);
     logger.debug('received lambda event')
     logger.debug(event)
 

--- a/src/instrumentation/LambdaInstrumentationWrapper.ts
+++ b/src/instrumentation/LambdaInstrumentationWrapper.ts
@@ -9,7 +9,7 @@ export function LambdaRequestHook(span, {event, context}){
     const lambdaRequestContext = event['requestContext'];
 
     if(!headers || !lambdaRequestContext){
-        logger.warn("Received unexpected lambda event that doesnt look like an ApiGateway event")
+        logger.warn("Received unexpected lambda event that doesnt look like an ApiGateway event tracing will be skipped")
         logger.warn("Is the event an ApiGateway event?")
         logger.warn(event)
         return

--- a/test/instrumentation/LambdaInstrumentationWrapperTest.ts
+++ b/test/instrumentation/LambdaInstrumentationWrapperTest.ts
@@ -263,4 +263,19 @@ describe("manually instrument lambda function", () => {
             '\t"req-body": "some-data"\n' +
             '}')
     })
+
+    it('can handle non-apigateway events gracefully', async () => {
+        async function myHandler(event, context, callback){
+            return {"foo": "bar"}
+        }
+
+        let wrappedHandler = agentTestWrapper.instrumentLambda(myHandler)
+        let errorCount = 0
+        try {
+            await wrappedHandler({"some-different-event": "foo"}, {}, () => {})
+        } catch(error){
+            errorCount += 1
+        }
+        expect(errorCount).to.equal(0)
+    })
 })


### PR DESCRIPTION
If we receive an event that doesn't look like an api gateway event we should continue without trying to read further into the event as for event driven lambdas we don't offer header/body capture.

(this has come up a few times so the log is a question to help guide CS/users towards what the issue may be)