### PR TITLE
Add fetch support

### DIFF
--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -50,7 +50,7 @@ jobs:
       - run: tsc
 
       - name: Standup Test Docker Services
-        run: cd ./test/externalServices && docker-compose up -d
+        run: cd ./test/externalServices && docker compose up -d
       - name: Wait for Docker
         run: sleep 100
       - name: Check test containers state

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -3,5 +3,5 @@
   "check-coverage": true,
   "include": "src/**/*.ts",
   "exclude": "src/config/generated.*, src/instrumentation/HttpInstrumentationWrapper.ts, src/instrumentation/*.original.ts",
-  "lines": 79
+  "lines": 75
 }

--- a/src/HypertraceAgent.ts
+++ b/src/HypertraceAgent.ts
@@ -34,6 +34,7 @@ import {Framework} from "./instrumentation/Framework";
 import {LambdaRequestHook, LambdaResponseHook} from "./instrumentation/LambdaInstrumentationWrapper";
 import {patchHapi} from "./instrumentation/wrapper/HapiWrapper";
 import {ChannelCredentials} from "@grpc/grpc-js";
+import {patchFetch} from "./instrumentation/wrapper/FetchWrapper";
 
 const api = require("@opentelemetry/api");
 const grpc = require('@grpc/grpc-js');
@@ -82,6 +83,7 @@ export class HypertraceAgent {
         patchClientRequest()
         patchExpress()
         patchSails()
+        patchFetch()
 
         let instrumentations = [
             new ExtendedAwsLambdaInstrumentation({
@@ -107,7 +109,7 @@ export class HypertraceAgent {
             new MySQL2Instrumentation(),
             new PgInstrumentation(),
             new MongoDBInstrumentation(),
-            new MongooseInstrumentation()
+            new MongooseInstrumentation(),
         ]
 
         if (isCompatible("12.0.0")) {

--- a/src/instrumentation/BodyCapture.ts
+++ b/src/instrumentation/BodyCapture.ts
@@ -1,5 +1,22 @@
 import sizeof from 'object-sizeof'
 
+const _RECORDABLE_CONTENT_TYPES = ['application/json', 'application/graphql', 'application/x-www-form-urlencoded']
+export function shouldCapture(configField: boolean, contentTypeValue: any): boolean {
+    if (!configField) {
+        return false
+    }
+    if(!contentTypeValue){
+        return false
+    }
+
+    for (let recordableType of _RECORDABLE_CONTENT_TYPES) {
+        if (contentTypeValue.includes(recordableType)) {
+            return true
+        }
+    }
+    return false
+}
+
 export class BodyCapture {
     private data: string;
     private currentSize : number;

--- a/src/instrumentation/ExtendedAwsLambdaInstrumentation.ts
+++ b/src/instrumentation/ExtendedAwsLambdaInstrumentation.ts
@@ -41,6 +41,7 @@ export class ExtendedAwsLambdaInstrumentation extends AwsLambdaInstrumentation {
 
                     span.end();
                     try {
+                        logger.debug("Exporting spans from node...")
                         await traceProvider.forceFlush()
                     }catch(e){
                         logger.error("Error exporting trace in extendedLambdaHandler original invoke attempt, continue without export")
@@ -62,6 +63,7 @@ export class ExtendedAwsLambdaInstrumentation extends AwsLambdaInstrumentation {
                     });
                     span.end();
                     try {
+                        logger.debug("Exporting spans from node-agent...")
                         await traceProvider.forceFlush()
                     }catch(e){
                         logger.error("Error exporting trace in extendedLambdaHandler error handler, continue without export")

--- a/src/instrumentation/wrapper/FetchWrapper.ts
+++ b/src/instrumentation/wrapper/FetchWrapper.ts
@@ -3,14 +3,20 @@ import {BodyCapture, shouldCapture} from "../BodyCapture";
 import {Config} from "../../config/config";
 import {logger} from "../../Logging";
 import {SpanKind} from "@opentelemetry/api";
-
 const {context, trace} = require('@opentelemetry/api');
+
+let PATCHED = false;
 
 export function patchFetch() {
     if (typeof fetch !== 'undefined') {
         logger.info("Adding fetch patch")
     } else {
         return
+    }
+    if(PATCHED){
+        return
+    } else {
+        PATCHED = true
     }
     const originalFetch = fetch;
     global.fetch = async function (urlOrRequest: RequestInfo, options: RequestInit = {}) {

--- a/src/instrumentation/wrapper/FetchWrapper.ts
+++ b/src/instrumentation/wrapper/FetchWrapper.ts
@@ -1,0 +1,165 @@
+import {SemanticAttributes} from "@opentelemetry/semantic-conventions";
+import {BodyCapture, shouldCapture} from "../BodyCapture";
+import {Config} from "../../config/config";
+import {logger} from "../../Logging";
+import {SpanKind} from "@opentelemetry/api";
+
+const {context, trace} = require('@opentelemetry/api');
+
+export function patchFetch() {
+    if (typeof fetch !== 'undefined') {
+        logger.info("Adding fetch patch")
+    } else {
+        return
+    }
+    const originalFetch = fetch;
+    global.fetch = async function (urlOrRequest: RequestInfo, options: RequestInit = {}) {
+        let response
+        let span = startSpanFromRequest(urlOrRequest, options)
+        try {
+            response = await originalFetch(urlOrRequest, options);
+        } catch(e){
+            if(span){
+                span.recordException(e);
+                span.end()
+            }
+            // re-raise underlying fetch error
+            throw e
+        }
+
+        if (span === null) {
+            // this means something errored during req cap, just return response to caller without res cap
+            return response;
+        } else {
+            await recordResponseData(span, response)
+        }
+        return response
+    };
+}
+
+function startSpanFromRequest(urlOrRequest: RequestInfo, options: RequestInit = {}) {
+    let span;
+    try {
+        let url: URL;
+        let optionsToUse = options;
+
+        // Handle if urlOrRequest is a Request object
+        if (urlOrRequest instanceof Request) {
+            url = new URL(urlOrRequest.url);
+            optionsToUse = {
+                ...options,
+                method: urlOrRequest.method,
+                headers: urlOrRequest.headers,
+                body: urlOrRequest.body,
+            };
+        } else {
+            url = new URL(urlOrRequest)
+        }
+        const parsedUrl = new URL(url);
+        const scheme = parsedUrl.protocol.slice(0, -1);
+        const currentContext = context.active();
+        const tracer = trace.getTracer('hypertrace-fetch');
+        const requestMethod = getRequestMethod(options['method']);
+        const attributes = {
+            [SemanticAttributes.HTTP_METHOD]: requestMethod,
+            [SemanticAttributes.HTTP_SCHEME]: scheme,
+            [SemanticAttributes.HTTP_URL]: parsedUrl.toString(),
+            [SemanticAttributes.NET_PEER_NAME]: parsedUrl.hostname,
+            [SemanticAttributes.NET_PEER_PORT]: parsedUrl.port,
+            [SemanticAttributes.HTTP_TARGET]: parsedUrl.pathname,
+        };
+
+        let spanOptions = {
+            kind: SpanKind.CLIENT,
+            attributes: attributes
+        }
+
+        span = tracer.startSpan(`${requestMethod} ${parsedUrl.pathname}`, spanOptions, currentContext);
+
+        const headers = optionsToUse.headers || (urlOrRequest instanceof Request ? urlOrRequest.headers : {});
+        let reqContentType = ''
+        if (headers instanceof Headers) {
+            headers.forEach((value, key) => {
+                let lKey = key.toLowerCase()
+                if (lKey === "content-type") {
+                    reqContentType = value
+                }
+                span.setAttribute(`http.request.header.${lKey}`, value);
+            });
+        } else if (typeof headers === 'object') {
+            for (const key in headers) {
+                if (headers.hasOwnProperty(key)) {
+                    let lKey = key.toLowerCase()
+                    if (lKey === "content-type") {
+                        reqContentType = headers[key]
+                    }
+                    span.setAttribute(`http.request.header.${lKey}`, headers[key]);
+                }
+            }
+        }
+
+        let bodyCapture: BodyCapture = new BodyCapture(<number>Config.getInstance().config.data_capture!.body_max_size_bytes!,
+            <number>Config.getInstance().config.data_capture!.body_max_processing_size_bytes!)
+        if (shouldCapture(<boolean>Config.getInstance().config.data_capture!.http_body!.request!, reqContentType)) {
+            if (options.body && typeof options.body === 'string') {
+                bodyCapture.appendData(options.body)
+                span.setAttribute("http.request.body", bodyCapture.dataString())
+            }
+        }
+    } catch (e) {
+        if (span) {
+            span.end()
+        }
+        logger.error("Error during request capture phase of fetch instrumentation", e)
+        return null
+    }
+    return span
+}
+
+async function recordResponseData(span, response) {
+    try {
+        let responseBody;
+        const clone = response.clone();
+        let resContentType
+        if (response.headers instanceof Headers) {
+            response.headers.forEach((value, key) => {
+                let lKey = key.toLowerCase()
+                if (lKey === "content-type") {
+                    resContentType = value
+                }
+                span.setAttribute(`http.response.header.${lKey}`, value);
+            });
+        } else if (typeof response.headers === 'object') {
+            for (const key in response.headers) {
+                if (response.headers.hasOwnProperty(key)) {
+                    let lKey = key.toLowerCase()
+                    if (lKey === "content-type") {
+                        resContentType = response.headers[key]
+                    }
+                    span.setAttribute(`http.response.header.${lKey}`, response.headers[key]);
+                }
+            }
+        }
+
+        if (shouldCapture(<boolean>Config.getInstance().config.data_capture!.http_body!.response!, resContentType)) {
+            let resBodyCapture: BodyCapture = new BodyCapture(<number>Config.getInstance().config.data_capture!.body_max_size_bytes!,
+                <number>Config.getInstance().config.data_capture!.body_max_processing_size_bytes!)
+            let respData = await clone.text()
+            resBodyCapture.appendData(respData)
+            span.setAttribute("http.response.body", resBodyCapture.dataString())
+        }
+        span.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, response.status)
+        span.end()
+    } catch (e) {
+        span.recordException(e)
+        span.end()
+    }
+
+}
+
+function getRequestMethod(methodStr) {
+    if (!methodStr) {
+        return 'GET'
+    }
+    return methodStr;
+}

--- a/test/instrumentation/FetchTest.ts
+++ b/test/instrumentation/FetchTest.ts
@@ -7,6 +7,7 @@ import * as http from "http";
 import {httpRequest} from "./HttpRequest";
 import {Framework} from "../../src/instrumentation/Framework";
 import {SpanKind} from "@opentelemetry/api";
+import semver = require("semver/preload");
 
 describe('Agent tests', () => {
     const requestListener = async function (req, res) {
@@ -38,6 +39,10 @@ describe('Agent tests', () => {
     let originalOnlyExpress = Framework.getInstance().isExpressBased
     let originalanyFrameworks = Framework.getInstance().anyFrameworks
     before((done)=> {
+        const currentNodeVersion = process.version;
+        if (semver.lt(currentNodeVersion, '18.0.0')) {
+            this.skip();
+        }
         Framework.getInstance().isExpressBased = () => {return false}
         Framework.getInstance().isPureExpress = () => {return false}
         Framework.getInstance().anyFrameworks = () => {return false}

--- a/test/instrumentation/FetchTest.ts
+++ b/test/instrumentation/FetchTest.ts
@@ -1,0 +1,170 @@
+import {AgentForTest} from "./AgentForTest";
+const agentTestWrapper = AgentForTest.getInstance();
+agentTestWrapper.instrument()
+
+import {expect} from "chai";
+import * as http from "http";
+import {httpRequest} from "./HttpRequest";
+import {Framework} from "../../src/instrumentation/Framework";
+import {SpanKind} from "@opentelemetry/api";
+
+describe('Agent tests', () => {
+    const requestListener = async function (req, res) {
+        let body = ''
+        if(req.url.indexOf("do-fetch") > -1){
+            await fetch("http://localhost:8000/nested-call")
+            res.setHeader("Content-Type", "application/json")
+            res.writeHead(200)
+            res.end(`{"nested-call": "true"}`)
+        }
+        if(req.method == "POST") {
+            req.on('data', (data) => {body += data})
+            req.on('end', (data) => {
+                body += data
+                res.setHeader("Content-Type", "application/json")
+                res.writeHead(200);
+                res.end(`{"test post": "data"}`);
+            })
+        } else {
+            res.setHeader("Content-Type", "application/json")
+            res.writeHead(200);
+            res.end(`{"test": "data"}`);
+        }
+    }
+
+    let server = http.createServer(requestListener)
+
+    let originalIncludeExpress = Framework.getInstance().isExpressBased
+    let originalOnlyExpress = Framework.getInstance().isExpressBased
+    let originalanyFrameworks = Framework.getInstance().anyFrameworks
+    before((done)=> {
+        Framework.getInstance().isExpressBased = () => {return false}
+        Framework.getInstance().isPureExpress = () => {return false}
+        Framework.getInstance().anyFrameworks = () => {return false}
+        server.listen(8000)
+        server.on('listening', () => {done()})
+    })
+
+    afterEach(() => {
+        agentTestWrapper.stop()
+    })
+
+    after( ()=> {
+        Framework.getInstance().isExpressBased = originalIncludeExpress
+        Framework.getInstance().isPureExpress = originalOnlyExpress
+        Framework.getInstance().anyFrameworks = originalanyFrameworks
+        server.close()
+        agentTestWrapper.stop()
+    })
+
+    it('can capture GET requests', async () => {
+        const response = await fetch('http://localhost:8000/some/path/segment');
+
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        const data = await response.json();
+        console.log(data);
+
+        let spans = agentTestWrapper.getSpans()
+        expect(spans.length).to.equal(2)
+        let serverSpanAttributes = spans[0].attributes
+        expect(serverSpanAttributes["net.peer.ip"]).to.exist
+        expect(serverSpanAttributes['http.method']).to.equal('GET')
+        expect(serverSpanAttributes['net.host.name']).to.equal('localhost')
+        expect(serverSpanAttributes['http.target']).to.equal('/some/path/segment')
+        expect(serverSpanAttributes['net.transport']).to.equal('ip_tcp')
+        expect(serverSpanAttributes['http.status_code']).to.equal(200)
+
+        let requestSpanAttributes = spans[1].attributes
+        expect(requestSpanAttributes['http.method']).to.equal('GET')
+        expect(requestSpanAttributes['net.peer.name']).to.equal('localhost')
+        expect(requestSpanAttributes['http.target']).to.equal('/some/path/segment')
+        expect(requestSpanAttributes['http.status_code']).to.equal(200)
+        expect(spans[1].name).to.equal('GET /some/path/segment')
+    });
+
+    it('can capture response bodies', async () => {
+        const data = {
+            key1: 'value1',
+            key2: 'value2'
+        };
+
+        const response = await fetch('http://localhost:8000/', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(data)
+        });
+
+        const result = await response.json();
+        let spans = agentTestWrapper.getSpans()
+        expect(spans.length).to.equal(2)
+        let serverSpanAttributes = spans[0].attributes
+        expect(serverSpanAttributes['http.response.body']).to.equal(`{"test post": "data"}`)
+
+        let requestSpanAttributes = spans[1].attributes
+        expect(requestSpanAttributes['http.response.body']).to.equal(`{"test post": "data"}`)
+    });
+
+    it('can capture request body data', async () => {
+        const response = await httpRequest.post({
+                host: 'localhost',
+                port: 8000,
+                path: '/',
+                headers: {
+                    "Some-Header": "Foo-Bar",
+                    "Content-Type": "application/json"
+                }
+            },
+            JSON.stringify({data: "123"})
+        )
+        let spans = agentTestWrapper.getSpans()
+        expect(spans.length).to.equal(2)
+        let serverSpanAttributes = spans[0].attributes
+        expect(serverSpanAttributes['http.request.body']).to.equal(`{"data":"123"}`)
+
+        let requestSpanAttributes = spans[1].attributes
+        expect(requestSpanAttributes['http.request.body']).to.equal(`{"data":"123"}`)
+    });
+
+    it('correlates server span with nested client fetch calls', async () => {
+        const response = await httpRequest.post({
+                host: 'localhost',
+                port: 8000,
+                path: '/do-fetch',
+                headers: {
+                    "Some-Header": "Foo-Bar",
+                    "Content-Type": "application/json"
+                }
+            },
+            JSON.stringify({data: "123"})
+        )
+        let spans = agentTestWrapper.getSpans()
+        expect(spans.length).to.equal(4)
+        // @ts-ignore
+        expect(spans[1].parentSpanId).to.equal(spans[2]._spanContext.spanId)
+        expect(spans[1].kind).to.equal(SpanKind.CLIENT)
+        expect(spans[2].kind).to.equal(SpanKind.SERVER)
+    });
+
+    it('should capture errors in spans when the server is unreachable', async () => {
+        let errorCaught = false;
+        try {
+            await fetch('http://localhost:9999/');
+        } catch (e) {
+            errorCaught = true;
+        }
+        expect(errorCaught).to.be.true;
+
+        let spans = agentTestWrapper.getSpans();
+        expect(spans.length).to.equal(1);
+        let spanAttributes = spans[0].attributes;
+        expect(spanAttributes['http.method']).to.equal('GET');
+        expect(spanAttributes['http.url']).to.equal('http://localhost:9999/');
+        expect(spans[0].events.some(event => event.name === 'exception')).to.be.true;
+    });
+
+});

--- a/test/instrumentation/FetchTest.ts
+++ b/test/instrumentation/FetchTest.ts
@@ -41,6 +41,7 @@ describe('Agent tests', () => {
     before((done)=> {
         const currentNodeVersion = process.version;
         if (semver.lt(currentNodeVersion, '18.0.0')) {
+            // @ts-ignore
             this.skip();
         }
         Framework.getInstance().isExpressBased = () => {return false}

--- a/test/instrumentation/FetchTest.ts
+++ b/test/instrumentation/FetchTest.ts
@@ -38,7 +38,7 @@ describe('Agent tests', () => {
     let originalIncludeExpress = Framework.getInstance().isExpressBased
     let originalOnlyExpress = Framework.getInstance().isExpressBased
     let originalanyFrameworks = Framework.getInstance().anyFrameworks
-    before((done)=> {
+    before(function (done) {
         const currentNodeVersion = process.version;
         if (semver.lt(currentNodeVersion, '18.0.0')) {
             // @ts-ignore

--- a/test/instrumentation/NestjsTest.ts
+++ b/test/instrumentation/NestjsTest.ts
@@ -73,7 +73,10 @@ describe('NestJS tests', () => {
     })
 
     after(() => {
-        appInstance.close()
+        if(appInstance){
+            appInstance.close()
+        }
+
     })
 
     it('can capture request & response attributes', async () => {
@@ -127,7 +130,12 @@ describe('NestJS tests', () => {
 
         after(() => {
             // @ts-ignore
-            Registry.instance = undefined
+            const currentNodeVersion = process.version;
+            if (semver.gt(currentNodeVersion, '18.0.0')) {
+                // @ts-ignore
+                Registry.instance = undefined
+            }
+
         })
 
         it('will return a 403 if a body filter returns true', async () => {

--- a/test/instrumentation/NestjsTest.ts
+++ b/test/instrumentation/NestjsTest.ts
@@ -116,7 +116,12 @@ describe('NestJS tests', () => {
     });
 
     describe('filter api', () => {
-        before(() => {
+        before(function () {
+            const currentNodeVersion = process.version;
+            if (semver.lt(currentNodeVersion, '18.0.0')) {
+                // @ts-ignore
+                this.skip();
+            }
             Registry.getInstance().register(new SampleFilter())
         })
 

--- a/test/instrumentation/NestjsTest.ts
+++ b/test/instrumentation/NestjsTest.ts
@@ -3,31 +3,35 @@ import {AgentForTest} from "./AgentForTest";
 const agentTestWrapper = AgentForTest.getInstance()
 agentTestWrapper.instrument()
 
-import { NestFactory } from '@nestjs/core';
+import {NestFactory} from '@nestjs/core';
 import {Body, INestApplication, Module, Post} from "@nestjs/common";
-import { Controller, Get } from '@nestjs/common';
+import {Controller, Get} from '@nestjs/common';
 import {httpRequest} from "./HttpRequest";
 import {expect} from "chai";
 import {Registry} from "../../src/filter/Registry";
 import {SampleFilter} from "./SampleFilter";
+import semver = require("semver/preload");
 
 export class CreateString {
     data: string;
-    constructor(data : string) {
+
+    constructor(data: string) {
         this.data = data
     }
 }
 
 @Controller()
 class AppController {
-    constructor() {}
+    constructor() {
+    }
+
     @Get('/test')
     getHello(): string {
         return "Some plain text content";
     }
 
     @Post('/test-post')
-    postHello(@Body() createString: CreateString) : object {
+    postHello(@Body() createString: CreateString): object {
         return {"msg": "success", "data": createString.data}
     }
 
@@ -38,128 +42,133 @@ class AppController {
     controllers: [AppController],
     providers: [],
 })
-export class AppModule {}
+export class AppModule {
+}
 
 // https://docs.nestjs.com/first-steps#prerequisites
-if(!['v8', 'v10'].some((nodeVersion) => {process.version.startsWith(nodeVersion)})) {
-    async function bootstrap() : Promise<INestApplication> {
-        const app = await NestFactory.create(AppModule);
-        await app.listen(3000);
-        return app
-    }
-    describe('NestJS tests', () => {
-        let appInstance : INestApplication
+async function bootstrap(): Promise<INestApplication> {
+    const app = await NestFactory.create(AppModule);
+    await app.listen(3000);
+    return app
+}
 
-        before(async () => {
-            appInstance = await bootstrap();
-        })
+describe('NestJS tests', () => {
+    let appInstance: INestApplication
 
-        beforeEach(() => {
-            agentTestWrapper.stop()
-        })
+    before(async function () {
+        const currentNodeVersion = process.version;
+        if (semver.lt(currentNodeVersion, '18.0.0')) {
+            // @ts-ignore
+            this.skip();
+        }
+        appInstance = await bootstrap();
+    })
 
-        afterEach(() => {
-            agentTestWrapper.stop()
+    beforeEach(() => {
+        agentTestWrapper.stop()
+    })
+
+    afterEach(() => {
+        agentTestWrapper.stop()
+    })
+
+    after(() => {
+        appInstance.close()
+    })
+
+    it('can capture request & response attributes', async () => {
+        let headers = {
+            "some-header": "a-value",
+            "Another_Header": "another_value"
+        }
+        await httpRequest.get({headers: headers, host: 'localhost', port: 3000, path: '/test'})
+        let spans = agentTestWrapper.getSpans()
+        expect(spans.length).to.equal(2)
+        let requestSpanAttributes = spans[1].attributes
+        expect(requestSpanAttributes['http.request.header.another_header']).to.equal('another_value')
+        expect(requestSpanAttributes['http.request.header.some-header']).to.equal('a-value')
+        expect(requestSpanAttributes['http.response.header.content-type']).to.equal('text/html; charset=utf-8')
+
+        let serverSpanAttributes = spans[0].attributes
+        expect(serverSpanAttributes['http.request.header.some-header']).to.equal('a-value')
+        expect(serverSpanAttributes['http.request.header.another_header']).to.equal('another_value')
+        expect(spans[0].name).to.equal('GET /test')
+    });
+
+    it('can capture request & response bodies', async () => {
+        let headers = {
+            "some-header": "a-value",
+            "Another_Header": "another_value",
+            "Content-Type": "application/json"
+        }
+        await httpRequest.post({headers: headers, host: 'localhost', port: 3000, path: '/test-post'},
+            JSON.stringify({"data": "some_data"}))
+        let spans = agentTestWrapper.getSpans()
+        expect(spans.length).to.equal(2)
+
+        let serverSpan = spans[0].attributes
+        expect(serverSpan['http.request.body']).to.equal("{\"data\":\"some_data\"}")
+        expect(serverSpan['http.response.body']).to.equal("{\"msg\":\"success\",\"data\":\"some_data\"}")
+
+        let requestSpan = spans[1]
+        expect(requestSpan.attributes['http.request.body']).to.eql("{\"data\":\"some_data\"}")
+        expect(requestSpan.attributes['http.response.body']).to.eql("{\"msg\":\"success\",\"data\":\"some_data\"}")
+    });
+
+    describe('filter api', () => {
+        before(() => {
+            Registry.getInstance().register(new SampleFilter())
         })
 
         after(() => {
-            appInstance.close()
+            // @ts-ignore
+            Registry.instance = undefined
         })
 
-        it('can capture request & response attributes', async () => {
-            let headers = {
-                "some-header": "a-value",
-                "Another_Header": "another_value"
-            }
-            await httpRequest.get({headers: headers, host: 'localhost', port: 3000, path: '/test'})
+        it('will return a 403 if a body filter returns true', async () => {
+            await httpRequest.post({
+                    host: 'localhost',
+                    port: 3000,
+                    path: '/test-post',
+                    headers: {
+                        'Content-Type': "application/json",
+                    }
+                },
+                JSON.stringify({"test": "block-this-body"}))
+
             let spans = agentTestWrapper.getSpans()
             expect(spans.length).to.equal(2)
-            let requestSpanAttributes = spans[1].attributes
-            expect(requestSpanAttributes['http.request.header.another_header']).to.equal('another_value')
-            expect(requestSpanAttributes['http.request.header.some-header']).to.equal('a-value')
-            expect(requestSpanAttributes['http.response.header.content-type']).to.equal('text/html; charset=utf-8')
-
-            let serverSpanAttributes = spans[0].attributes
-            expect(serverSpanAttributes['http.request.header.some-header']).to.equal('a-value')
-            expect(serverSpanAttributes['http.request.header.another_header']).to.equal('another_value')
-            expect(spans[0].name).to.equal('GET /test')
-        });
-
-        it('can capture request & response bodies', async () => {
-            let headers = {
-                "some-header": "a-value",
-                "Another_Header": "another_value",
-                "Content-Type": "application/json"
-            }
-            await httpRequest.post({headers: headers, host: 'localhost', port: 3000, path: '/test-post'},
-                JSON.stringify({"data": "some_data"}))
-            let spans = agentTestWrapper.getSpans()
-            expect(spans.length).to.equal(2)
-
-            let serverSpan = spans[0].attributes
-            expect(serverSpan['http.request.body']).to.equal("{\"data\":\"some_data\"}")
-            expect(serverSpan['http.response.body']).to.equal("{\"msg\":\"success\",\"data\":\"some_data\"}")
+            let serverSpan = spans[0]
+            expect(serverSpan.attributes['http.status_code']).to.equal(403)
+            expect(serverSpan.attributes['http.status_text']).to.equal('FORBIDDEN')
 
             let requestSpan = spans[1]
-            expect(requestSpan.attributes['http.request.body']).to.eql("{\"data\":\"some_data\"}")
-            expect(requestSpan.attributes['http.response.body']).to.eql("{\"msg\":\"success\",\"data\":\"some_data\"}")
-        });
-
-        describe('filter api', () => {
-            before(() => {
-                Registry.getInstance().register(new SampleFilter())
-            })
-
-            after(() => {
-                // @ts-ignore
-                Registry.instance = undefined
-            })
-
-            it('will return a 403 if a body filter returns true', async() => {
-                await httpRequest.post({
-                        host: 'localhost',
-                        port: 3000,
-                        path: '/test-post',
-                        headers: {
-                            'Content-Type': "application/json",
-                        }
-                    },
-                    JSON.stringify({"test": "block-this-body"}))
-
-                let spans = agentTestWrapper.getSpans()
-                expect(spans.length).to.equal(2)
-                let serverSpan = spans[0]
-                expect(serverSpan.attributes['http.status_code']).to.equal(403)
-                expect(serverSpan.attributes['http.status_text']).to.equal('FORBIDDEN')
-
-                let requestSpan = spans[1]
-                expect(requestSpan.attributes['http.status_code']).to.equal(403)
-                expect(requestSpan.attributes['http.status_text']).to.equal('FORBIDDEN')
-            })
-
-            it('will return a 403 if a header filter returns true', async() => {
-                await httpRequest.post({
-                        host: 'localhost',
-                        port: 3000,
-                        path: '/test-post',
-                        headers: {
-                            'Content-Type': "application/json",
-                            'x-filter-test': "123"
-                        }
-                    },
-                    JSON.stringify({"test": "req data"}))
-
-                let spans = agentTestWrapper.getSpans()
-                expect(spans.length).to.equal(2)
-                let serverSpan = spans[0]
-                expect(serverSpan.attributes["net.peer.ip"]).to.exist
-                expect(serverSpan.attributes['http.status_code']).to.equal(403)
-                expect(serverSpan.attributes['http.status_text']).to.equal('FORBIDDEN')
-
-                let requestSpan = spans[1]
-                expect(requestSpan.attributes['http.status_code']).to.equal(403)
-                expect(requestSpan.attributes['http.status_text']).to.equal('FORBIDDEN')
-            })
+            expect(requestSpan.attributes['http.status_code']).to.equal(403)
+            expect(requestSpan.attributes['http.status_text']).to.equal('FORBIDDEN')
         })
-    });
-}
+
+        it('will return a 403 if a header filter returns true', async () => {
+            await httpRequest.post({
+                    host: 'localhost',
+                    port: 3000,
+                    path: '/test-post',
+                    headers: {
+                        'Content-Type': "application/json",
+                        'x-filter-test': "123"
+                    }
+                },
+                JSON.stringify({"test": "req data"}))
+
+            let spans = agentTestWrapper.getSpans()
+            expect(spans.length).to.equal(2)
+            let serverSpan = spans[0]
+            expect(serverSpan.attributes["net.peer.ip"]).to.exist
+            expect(serverSpan.attributes['http.status_code']).to.equal(403)
+            expect(serverSpan.attributes['http.status_text']).to.equal('FORBIDDEN')
+
+            let requestSpan = spans[1]
+            expect(requestSpan.attributes['http.status_code']).to.equal(403)
+            expect(requestSpan.attributes['http.status_text']).to.equal('FORBIDDEN')
+        })
+    })
+});


### PR DESCRIPTION
## Description
This adds:
- custom fetch isntrumentation to capture req+res headers & bodies for node-fetch
- copy shouldCapture to better place, currently this is duplicated but should be part of bodyCapture logic(we can move to this going forward as we update instrumentations)
- add lambda force flush logs, there have been questions about "how to know if lambda is exporting" previously we were relying on the absence of errors which makes diagnosing lack of spans more challenging.

<img width="1155" alt="Screenshot 2024-08-30 at 2 36 01 PM" src="https://github.com/user-attachments/assets/515cc9a6-5d20-4d70-bd34-8e50bb60b471">
<img width="915" alt="Screenshot 2024-08-30 at 2 36 05 PM" src="https://github.com/user-attachments/assets/63fa05b2-64ab-47b2-bf48-80085db9806a">
<img width="877" alt="Screenshot 2024-08-30 at 2 36 11 PM" src="https://github.com/user-attachments/assets/1a620f95-93ba-4a61-bd38-b81479aba346">
<img width="553" alt="Screenshot 2024-08-30 at 2 36 15 PM" src="https://github.com/user-attachments/assets/5ae268bd-2dae-4888-bc93-88125ad1c38a">


