### PR TITLE
ENG-53423: add handling for empty responses

### DIFF
--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -20,7 +20,7 @@ jobs:
       - run: npm run generate_pb
 
       - name: Cache proto
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: proto
           path: ./src/config/generated.*
@@ -42,7 +42,7 @@ jobs:
       - run: npm install
       - run: npm install -g typescript@5.4.2
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: proto
           path: ./src/config/

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -29,7 +29,7 @@ jobs:
     needs: generate_proto
     strategy:
       matrix:
-        node_version: [ "14", "16", "18", "20" ]
+        node_version: [ "18", "20", "22" ]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,11 +7,11 @@ jobs:
   generate_proto:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: '16'
       - run: npm install
@@ -27,8 +27,8 @@ jobs:
     runs-on: ubuntu-20.04
     needs: generate_proto
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "16"
           registry-url: 'https://registry.npmjs.org'
@@ -46,7 +46,7 @@ jobs:
       - run: npm install
       - run: npm install -g typescript@5.4.2
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: proto
           path: ./src/config/

--- a/src/instrumentation/ExtendedAwsLambdaInstrumentation.ts
+++ b/src/instrumentation/ExtendedAwsLambdaInstrumentation.ts
@@ -24,8 +24,14 @@ export class ExtendedAwsLambdaInstrumentation extends AwsLambdaInstrumentation {
 
             // @ts-ignore
             if (config.requestHook) {
-                // @ts-ignore
-                config.requestHook(span, {event, context: lambdaContext});
+                try{
+                    // @ts-ignore
+                    config.requestHook(span, {event, context: lambdaContext});
+                }catch(e){
+                    logger.debug("Error processing request hook")
+                    logger.debug(e)
+                }
+
             }
 
             return otelContext.with(trace.setSpan(otelContext.active(), span), async () => {
@@ -35,8 +41,14 @@ export class ExtendedAwsLambdaInstrumentation extends AwsLambdaInstrumentation {
 
                     // @ts-ignore
                     if (config.responseHook) {
-                        // @ts-ignore
-                        config.responseHook(span, {err: null, res: result});
+                        try{
+                            // @ts-ignore
+                            config.responseHook(span, {err: null, res: result});
+                        }catch(e){
+                            logger.debug("Error processing success state response hook")
+                            logger.debug(e)
+                        }
+
                     }
 
                     span.end();
@@ -52,8 +64,14 @@ export class ExtendedAwsLambdaInstrumentation extends AwsLambdaInstrumentation {
                 } catch (error) {
                     // @ts-ignore
                     if (config.responseHook) {
-                        // @ts-ignore
-                        config.responseHook(span, {err: error});
+                        try{
+                            // @ts-ignore
+                            config.responseHook(span, {err: error});
+                        }catch(e){
+                            logger.debug("Error processing error state response hook")
+                            logger.debug(e)
+                        }
+
                     }
 
                     span.recordException(error);

--- a/src/instrumentation/LambdaInstrumentationWrapper.ts
+++ b/src/instrumentation/LambdaInstrumentationWrapper.ts
@@ -62,7 +62,7 @@ export function LambdaRequestHook(span, {event, context}){
 }
 
 export function LambdaResponseHook(span, {err, res}) : void {
-    if(err && !res){
+    if(err || !res){
         return
     }
     let statusCode = res['statusCode']

--- a/test/instrumentation/LambdaInstrumentationWrapperTest.ts
+++ b/test/instrumentation/LambdaInstrumentationWrapperTest.ts
@@ -278,4 +278,18 @@ describe("manually instrument lambda function", () => {
         }
         expect(errorCount).to.equal(0)
     })
+
+    it('can handle non-apigateway events without a response gracefully', async () => {
+        async function myHandler(event, context, callback){
+        }
+
+        let wrappedHandler = agentTestWrapper.instrumentLambda(myHandler)
+        let errorCount = 0
+        try {
+            await wrappedHandler({"some-different-event": "foo"}, {}, () => {})
+        } catch(error){
+            errorCount += 1
+        }
+        expect(errorCount).to.equal(0)
+    })
 })


### PR DESCRIPTION
If user lambda doesn't return any response but it's not an error case our current parsing will error since we expect res to be defined.

Added additional error handling to prevent our hooks from surfacing any errors in lambda instrumentation to user.